### PR TITLE
Improve the interface

### DIFF
--- a/lib/digestif_bigstring.ml
+++ b/lib/digestif_bigstring.ml
@@ -53,16 +53,25 @@ let rpad a size x =
   fill b l (size - l) x;
   b
 
-exception Break
+exception Break of int
 
-let equal a b =
+let compare a b =
   if length a <> length b
-  then false
-  else try
-         for i = 0 to length a - 1
-         do if get a i <> get b i then raise Break done;
-         true
-       with Break -> false
+  then (if length a < length b then 0 - (Char.code (get b (length a))) else (Char.code (get a (length b))))
+  else
+    try
+      for i = 0 to length a - 1
+      do if get a i <> get b i then raise (Break ((Char.code (get a i)) - (Char.code (get b i)))) done;
+      0
+    with Break n -> n
+
+let eq a b = compare a b = 0
+let neq a b = not (eq a b)
+
+let iter f x =
+  let l = length x in
+
+  for i = 0 to l - 1 do f (get x i) done
 
 let empty = create 0
 

--- a/lib/digestif_bytes.ml
+++ b/lib/digestif_bytes.ml
@@ -25,3 +25,6 @@ let rpad a size x =
   blit a 0 b 0 l;
   fill b l (size - l) x;
   b
+
+let eq a b = Bytes.compare a b = 0
+let neq a b = not (eq a b)

--- a/lib/rakia.ml
+++ b/lib/rakia.ml
@@ -1,5 +1,3 @@
-let () = Printexc.record_backtrace true
-
 module Bi         = Digestif_bigstring
 module By         = Digestif_bytes
 module Native     = Rakia_native

--- a/lib/rakia.ml
+++ b/lib/rakia.ml
@@ -13,29 +13,31 @@ sig
   module Bigstring :
   sig
     type buffer = Native.ba
+    type t = Native.ba
 
     val init        : unit -> ctx
     val feed        : ctx -> buffer -> unit
-    val get         : ctx -> buffer
+    val get         : ctx -> t
 
-    val digest      : buffer -> buffer
-    val digestv     : buffer list -> buffer
-    val hmac        : key:buffer -> buffer -> buffer
-    val hmacv       : key:buffer -> buffer list -> buffer
+    val digest      : buffer -> t
+    val digestv     : buffer list -> t
+    val hmac        : key:buffer -> buffer -> t
+    val hmacv       : key:buffer -> buffer list -> t
   end
 
   module Bytes :
   sig
     type buffer = Native.st
+    type t = Native.st
 
     val init        : unit -> ctx
     val feed        : ctx -> buffer -> unit
-    val get         : ctx -> buffer
+    val get         : ctx -> t
 
-    val digest      : buffer -> buffer
-    val digestv     : buffer list -> buffer
-    val hmac        : key:buffer -> buffer -> buffer
-    val hmacv       : key:buffer -> buffer list -> buffer
+    val digest      : buffer -> t
+    val digestv     : buffer list -> t
+    val hmac        : key:buffer -> buffer -> t
+    val hmacv       : key:buffer -> buffer list -> t
   end
 end
 
@@ -75,6 +77,7 @@ struct
   module Bytes =
   struct
     type buffer = Native.st
+    type t = Native.st
 
     let init () =
       let t = Bi.create ctx_size in
@@ -98,6 +101,7 @@ struct
   module Bigstring =
   struct
     type buffer = Native.ba
+    type t = Native.ba
 
     let init () =
       let t = Bi.create ctx_size in
@@ -193,6 +197,7 @@ struct
   module Bytes =
   struct
     type buffer = Native.st
+    type t = Native.st
 
     let init () =
       let t = Bi.create ctx_size in
@@ -227,6 +232,7 @@ struct
   module Bigstring =
   struct
     type buffer = Native.ba
+    type t = Native.ba
 
     let init () =
       let t = Bi.create ctx_size in

--- a/lib/rakia.mli
+++ b/lib/rakia.mli
@@ -19,6 +19,14 @@ sig
     val digestv : buffer list -> t
     val hmac    : key:buffer -> buffer -> t
     val hmacv   : key:buffer -> buffer list -> t
+
+    val compare : t -> t -> int
+    val eq      : t -> t -> bool
+    val neq     : t -> t -> bool
+
+    val pp      : Format.formatter -> t -> unit
+    val of_hex  : buffer -> t
+    val to_hex  : t -> buffer
   end
 
   module Bytes :
@@ -34,6 +42,14 @@ sig
     val digestv : buffer list -> t
     val hmac    : key:buffer -> buffer -> t
     val hmacv   : key:buffer -> buffer list -> t
+
+    val compare : t -> t -> int
+    val eq      : t -> t -> bool
+    val neq     : t -> t -> bool
+
+    val pp      : Format.formatter -> t -> unit
+    val of_hex  : buffer -> t
+    val to_hex  : t -> buffer
   end
 end
 
@@ -60,6 +76,10 @@ sig
   val digestv : hash -> Bytes.t list -> Bytes.t
   val mac     : hash -> key:Bytes.t -> Bytes.t -> Bytes.t
   val macv    : hash -> key:Bytes.t -> Bytes.t list -> Bytes.t
+
+  val pp      : hash -> Format.formatter -> Bytes.t -> unit
+  val of_hex  : hash -> Bytes.t -> Bytes.t
+  val to_hex  : hash -> Bytes.t -> Bytes.t
 end
 
 module Bigstring :
@@ -68,6 +88,10 @@ sig
   val digestv : hash -> Bi.t list -> Bi.t
   val mac     : hash -> key:Bi.t -> Bi.t -> Bi.t
   val macv    : hash -> key:Bi.t -> Bi.t list -> Bi.t
+
+  val pp      : hash -> Format.formatter -> Bi.t -> unit
+  val of_hex  : hash -> Bi.t -> Bi.t
+  val to_hex  : hash -> Bi.t -> Bi.t
 end
 
 val digest_size : hash -> int

--- a/lib/rakia.mli
+++ b/lib/rakia.mli
@@ -9,29 +9,31 @@ sig
   module Bigstring :
   sig
     type buffer = Bi.t
+    type t = Bi.t
 
     val init    : unit -> ctx
     val feed    : ctx -> buffer -> unit
-    val get     : ctx -> buffer
+    val get     : ctx -> t
 
-    val digest  : buffer -> buffer
-    val digestv : buffer list -> buffer
-    val hmac    : key:buffer -> buffer -> buffer
-    val hmacv   : key:buffer -> buffer list -> buffer
+    val digest  : buffer -> t
+    val digestv : buffer list -> t
+    val hmac    : key:buffer -> buffer -> t
+    val hmacv   : key:buffer -> buffer list -> t
   end
 
   module Bytes :
   sig
     type buffer = Bytes.t
+    type t = Bytes.t
 
     val init    : unit -> ctx
     val feed    : ctx -> buffer -> unit
-    val get     : ctx -> buffer
+    val get     : ctx -> t
 
-    val digest  : buffer -> buffer
-    val digestv : buffer list -> buffer
-    val hmac    : key:buffer -> buffer -> buffer
-    val hmacv   : key:buffer -> buffer list -> buffer
+    val digest  : buffer -> t
+    val digestv : buffer list -> t
+    val hmac    : key:buffer -> buffer -> t
+    val hmacv   : key:buffer -> buffer list -> t
   end
 end
 

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -6,7 +6,7 @@
 
 open Topkg
 
-let opam = Pkg.opam_file ~lint_deps_excluding:None "opam"
+let opam = Pkg.opam_file ~lint_deps_excluding:(Some [ "ocamlbuild"; "topkg"; "ocaml"; "ocamlfind" ]) "opam"
 let alcotest = Conf.with_pkg ~default:false "alcotest"
 
 let () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -16,11 +16,11 @@ sig
   val create : int -> t
   val sub    : t -> int -> int -> t
   val length : t -> int
-  val equal : t -> t -> bool
-  val pp : t Fmt.t
+  val eq     : t -> t -> bool
+  val pp     : t Fmt.t
 end
 
-type 'buffer inputs = (module BIntf with type t = 'buffer) -> ('buffer * 'buffer) list
+type 'buffer inputs  = (module BIntf with type t = 'buffer) -> ('buffer * 'buffer) list
 type 'buffer results = (module BIntf with type t = 'buffer) -> 'buffer list
 
 let hex (type buffer) (module B : BIntf with type t = buffer) str : buffer =
@@ -47,7 +47,6 @@ let hex (type buffer) (module B : BIntf with type t = buffer) str : buffer =
   with
   | (_ , _, Some _) -> raise (Invalid_argument "hex: dangling nibble")
   | (cs, i, _     ) -> B.sub cs 0 i
-
 
 let inputs : type buffer. buffer inputs = fun (module B) ->
   let hex = hex (module B) in
@@ -298,7 +297,7 @@ let test_hmac
   : type buffer. (module BIntf with type t = buffer) -> (Rakia.hash -> key:buffer -> buffer -> buffer) -> Rakia.hash -> int -> ((buffer * buffer) * buffer) -> unit
   = fun (module B) hmac hash idx ((key, data), result) ->
   let computed = hmac hash ~key:key data in
-  Alcotest.(check (Alcotest.testable B.pp B.equal)) "hmac" result (if idx == 4 then B.(sub computed 0 (length result)) else computed)
+  Alcotest.(check (Alcotest.testable B.pp B.eq)) "hmac" result (if idx == 4 then B.(sub computed 0 (length result)) else computed)
 
 type 'a buffer =
   | Bytes     : (module BIntf with type t = Bytes.t) -> Bytes.t buffer
@@ -339,6 +338,8 @@ struct
   let pp fmt by =
     for i = 0 to length by
     do Format.fprintf fmt "%c" (get by i) done
+
+  let eq a b = compare a b = 0
 end
 
 let () =


### PR DESCRIPTION
I add some types and functions to improve the interface of the Rakia sub-library:

* `type t` to represent the hash
* `val eq` and `val neq` to compare the hash
* `val compare` to sort a list of hashes
* `val pp`, `val of_hex`, `val to_hex` to have _easy-to-use_ functions between a pretty-print of the hash and the hash

Note: I removed a forgotten `Printexc.record_backtrace` and excluded some packages (when we check with the `_tags` file) needed only to compile.