### PR TITLE
Improve api

### DIFF
--- a/common/digestif.mli
+++ b/common/digestif.mli
@@ -10,22 +10,24 @@ sig
     type ctx
     type t = Bi.t
 
-    val init    : unit -> ctx
-    val feed    : ctx -> buffer -> unit
-    val get     : ctx -> t
+    val init           : unit -> ctx
+    val feed           : ctx -> buffer -> unit
+    val feed_bytes     : ctx -> Bytes.t -> unit
+    val feed_bigstring : ctx -> Bi.t -> unit
+    val get            : ctx -> t
 
-    val digest  : buffer -> t
-    val digestv : buffer list -> t
-    val hmac    : key:buffer -> buffer -> t
-    val hmacv   : key:buffer -> buffer list -> t
+    val digest         : buffer -> t
+    val digestv        : buffer list -> t
+    val hmac           : key:buffer -> buffer -> t
+    val hmacv          : key:buffer -> buffer list -> t
 
-    val compare : t -> t -> int
-    val eq      : t -> t -> bool
-    val neq     : t -> t -> bool
+    val compare        : t -> t -> int
+    val eq             : t -> t -> bool
+    val neq            : t -> t -> bool
 
-    val pp      : Format.formatter -> t -> unit
-    val of_hex  : buffer -> t
-    val to_hex  : t -> buffer
+    val pp             : Format.formatter -> t -> unit
+    val of_hex         : buffer -> t
+    val to_hex         : t -> buffer
   end
 
   module Bytes :
@@ -34,22 +36,24 @@ sig
     type ctx
     type t = Bytes.t
 
-    val init    : unit -> ctx
-    val feed    : ctx -> buffer -> unit
-    val get     : ctx -> t
+    val init           : unit -> ctx
+    val feed           : ctx -> buffer -> unit
+    val feed_bytes     : ctx -> Bytes.t -> unit
+    val feed_bigstring : ctx -> Bi.t -> unit
+    val get            : ctx -> t
 
-    val digest  : buffer -> t
-    val digestv : buffer list -> t
-    val hmac    : key:buffer -> buffer -> t
-    val hmacv   : key:buffer -> buffer list -> t
+    val digest         : buffer -> t
+    val digestv        : buffer list -> t
+    val hmac           : key:buffer -> buffer -> t
+    val hmacv          : key:buffer -> buffer list -> t
 
-    val compare : t -> t -> int
-    val eq      : t -> t -> bool
-    val neq     : t -> t -> bool
+    val compare        : t -> t -> int
+    val eq             : t -> t -> bool
+    val neq            : t -> t -> bool
 
-    val pp      : Format.formatter -> t -> unit
-    val of_hex  : buffer -> t
-    val to_hex  : t -> buffer
+    val pp             : Format.formatter -> t -> unit
+    val of_hex         : buffer -> t
+    val to_hex         : t -> buffer
   end
 end
 

--- a/common/digestif_bigstring.ml
+++ b/common/digestif_bigstring.ml
@@ -27,6 +27,9 @@ let get_u8 : t -> int -> int = fun s i -> Char.code @@ get s i
 external get_u16 : t -> int -> int   = "%caml_bigstring_get16u"
 external get_u32 : t -> int -> int32 = "%caml_bigstring_get32u"
 external get_u64 : t -> int -> int64 = "%caml_bigstring_get64u"
+external by_get_u16 : Bytes.t -> int -> int   = "%caml_string_get16u"
+external by_get_u32 : Bytes.t -> int -> int32 = "%caml_string_get32u"
+external by_get_u64 : Bytes.t -> int -> int64 = "%caml_string_get64u"
 let get_nat : t -> int -> nativeint = fun s i ->
   if Sys.word_size = 32
   then Nativeint.of_int32 @@ get_u32 s i
@@ -52,9 +55,11 @@ let blit src src_off dst dst_off len =
 
   Array1.blit a b
 
-let blit_bytes src src_off dst dst_off len =
+let blit_from_bytes src src_off dst dst_off len =
   for i = 0 to len - 1
   do set dst (dst_off + i) (Bytes.get src (src_off + i)) done
+
+let blit_from_bigstring = blit
 
 let rpad a size x =
   let l = length a
@@ -118,20 +123,48 @@ let be32_to_cpu s i =
   then get_u32 s i
   else swap32 @@ get_u32 s i
 
+let be32_from_bigstring_to_cpu = be32_to_cpu
+
+let be32_from_bytes_to_cpu s i =
+  if Sys.big_endian
+  then by_get_u32 s i
+  else swap32 @@ by_get_u32 s i
+
 let le32_to_cpu s i =
   if Sys.big_endian
   then swap32 @@ get_u32 s i
   else get_u32 s i
+
+let le32_from_bigstring_to_cpu = le32_to_cpu
+
+let le32_from_bytes_to_cpu s i =
+  if Sys.big_endian
+  then swap32 @@ by_get_u32 s i
+  else by_get_u32 s i
 
 let be64_to_cpu s i =
   if Sys.big_endian
   then get_u64 s i
   else swap64 @@ get_u64 s i
 
+let be64_from_bigstring_to_cpu = be64_to_cpu
+
+let be64_from_bytes_to_cpu s i =
+  if Sys.big_endian
+  then by_get_u64 s i
+  else swap64 @@ by_get_u64 s i
+
 let le64_to_cpu s i =
   if Sys.big_endian
   then swap64 @@ get_u64 s i
   else get_u64 s i
+
+let le64_from_bigstring_to_cpu = le64_to_cpu
+
+let le64_from_bytes_to_cpu s i =
+  if Sys.big_endian
+  then swap64 @@ by_get_u64 s i
+  else by_get_u64 s i
 
 let benat_to_cpu s i =
   if Sys.big_endian

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -13,22 +13,24 @@ sig
     type ctx
     type t = Native.ba
 
-    val init        : unit -> ctx
-    val feed        : ctx -> buffer -> unit
-    val get         : ctx -> t
+    val init           : unit -> ctx
+    val feed           : ctx -> buffer -> unit
+    val feed_bytes     : ctx -> By.t -> unit
+    val feed_bigstring : ctx -> Bi.t -> unit
+    val get            : ctx -> t
 
-    val digest      : buffer -> t
-    val digestv     : buffer list -> t
-    val hmac        : key:buffer -> buffer -> t
-    val hmacv       : key:buffer -> buffer list -> t
+    val digest         : buffer -> t
+    val digestv        : buffer list -> t
+    val hmac           : key:buffer -> buffer -> t
+    val hmacv          : key:buffer -> buffer list -> t
 
-    val compare     : t -> t -> int
-    val eq          : t -> t -> bool
-    val neq         : t -> t -> bool
+    val compare        : t -> t -> int
+    val eq             : t -> t -> bool
+    val neq            : t -> t -> bool
 
-    val pp          : Format.formatter -> t -> unit
-    val of_hex      : buffer -> t
-    val to_hex      : t -> buffer
+    val pp             : Format.formatter -> t -> unit
+    val of_hex         : buffer -> t
+    val to_hex         : t -> buffer
   end
 
   module Bytes :
@@ -37,22 +39,24 @@ sig
     type ctx
     type t = Native.st
 
-    val init        : unit -> ctx
-    val feed        : ctx -> buffer -> unit
-    val get         : ctx -> t
+    val init           : unit -> ctx
+    val feed           : ctx -> buffer -> unit
+    val feed_bytes     : ctx -> By.t -> unit
+    val feed_bigstring : ctx -> Bi.t -> unit
+    val get            : ctx -> t
 
-    val digest      : buffer -> t
-    val digestv     : buffer list -> t
-    val hmac        : key:buffer -> buffer -> t
-    val hmacv       : key:buffer -> buffer list -> t
+    val digest         : buffer -> t
+    val digestv        : buffer list -> t
+    val hmac           : key:buffer -> buffer -> t
+    val hmacv          : key:buffer -> buffer list -> t
 
-    val compare : t -> t -> int
-    val eq      : t -> t -> bool
-    val neq     : t -> t -> bool
+    val compare        : t -> t -> int
+    val eq             : t -> t -> bool
+    val neq            : t -> t -> bool
 
-    val pp      : Format.formatter -> t -> unit
-    val of_hex  : buffer -> t
-    val to_hex  : t -> buffer
+    val pp             : Format.formatter -> t -> unit
+    val of_hex         : buffer -> t
+    val to_hex         : t -> buffer
   end
 end
 
@@ -113,6 +117,11 @@ struct
     let feed t buf =
       F.Bytes.update t buf 0 (By.length buf)
 
+    let feed_bytes = feed
+
+    let feed_bigstring t buf =
+      F.Bigstring.update t buf 0 (Bi.length buf)
+
     let get t =
       let res = By.create digest_size in
       F.Bytes.finalize t res 0;
@@ -139,6 +148,11 @@ struct
 
     let feed t buf =
       F.Bigstring.update t buf 0 (Bi.length buf)
+
+    let feed_bigstring = feed
+
+    let feed_bytes t buf =
+      F.Bytes.update t buf 0 (By.length buf)
 
     let get t =
       let res = Bi.create digest_size in
@@ -232,10 +246,15 @@ struct
 
     let init () =
       let t = Bi.create ctx_size in
-      ( Native.BLAKE2B.Bytes.init' t digest_size Bytes.empty 0 0; t )
+      ( Native.BLAKE2B.Bytes.init' t digest_size By.empty 0 0; t )
 
     let feed t buf =
-      F.Bytes.update t buf 0 (Bytes.length buf)
+      F.Bytes.update t buf 0 (By.length buf)
+
+    let feed_bytes = feed
+
+    let feed_bigstring t buf =
+      F.Bigstring.update t buf 0 (Bi.length buf)
 
     let get t =
       let res = Bytes.create digest_size in
@@ -274,6 +293,11 @@ struct
 
     let feed t buf =
       F.Bigstring.update t buf 0 (Bi.length buf)
+
+    let feed_bigstring = feed
+
+    let feed_bytes t buf =
+      F.Bytes.update t buf 0 (By.length buf)
 
     let get t =
       let res = Bi.create digest_size in

--- a/src-ocaml/baijiu_buffer.ml
+++ b/src-ocaml/baijiu_buffer.ml
@@ -5,9 +5,17 @@ sig
   val create : int -> buffer
   val set : buffer -> int -> char -> unit
   val be32_to_cpu : buffer -> int -> int32
+  val be32_from_bytes_to_cpu : Bytes.t -> int -> int32
+  val be32_from_bigstring_to_cpu : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int32
   val le32_to_cpu : buffer -> int -> int32
+  val le32_from_bytes_to_cpu : Bytes.t -> int -> int32
+  val le32_from_bigstring_to_cpu : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int32
   val be64_to_cpu : buffer -> int -> int64
+  val be64_from_bytes_to_cpu : Bytes.t -> int -> int64
+  val be64_from_bigstring_to_cpu : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int64
   val le64_to_cpu : buffer -> int -> int64
+  val le64_from_bytes_to_cpu : Bytes.t -> int -> int64
+  val le64_from_bigstring_to_cpu : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int64
   val cpu_to_be32 : buffer -> int -> int32 -> unit
   val cpu_to_be64 : buffer -> int -> int64 -> unit
   val cpu_to_le32 : buffer -> int -> int32 -> unit
@@ -16,6 +24,8 @@ sig
   val benat_to_cpu : buffer -> int -> nativeint
   val fill : buffer -> int -> int -> char -> unit
   val blit : buffer -> int -> buffer -> int -> int -> unit
+  val blit_from_bytes : Bytes.t -> int -> buffer -> int -> int -> unit
+  val blit_from_bigstring : (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> buffer -> int -> int -> unit
   val length : buffer -> int
   val copy : buffer -> buffer
   val sub : buffer -> int -> int -> buffer

--- a/src-ocaml/baijiu_sha224.ml
+++ b/src-ocaml/baijiu_sha224.ml
@@ -6,6 +6,8 @@ sig
 
   val init : unit -> ctx
   val feed : ctx -> buffer -> int -> int -> unit
+  val feed_bytes : ctx -> Bytes.t -> int -> int -> unit
+  val feed_bigstring : ctx -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int -> unit
   val get  : ctx -> t
 end
 

--- a/src-ocaml/baijiu_sha384.ml
+++ b/src-ocaml/baijiu_sha384.ml
@@ -6,6 +6,8 @@ sig
 
   val init : unit -> ctx
   val feed : ctx -> buffer -> int -> int -> unit
+  val feed_bytes : ctx -> Bytes.t -> int -> int -> unit
+  val feed_bigstring : ctx -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int -> unit
   val get  : ctx -> t
 end
 

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -15,6 +15,8 @@ sig
 
     val init        : unit -> ctx
     val feed        : ctx -> buffer -> unit
+    val feed_bytes     : ctx -> Bytes.t -> unit
+    val feed_bigstring : ctx -> Bi.t -> unit
     val get         : ctx -> t
 
     val digest      : buffer -> t
@@ -39,6 +41,8 @@ sig
 
     val init        : unit -> ctx
     val feed        : ctx -> buffer -> unit
+    val feed_bytes     : ctx -> Bytes.t -> unit
+    val feed_bigstring : ctx -> Bi.t -> unit
     val get         : ctx -> t
 
     val digest      : buffer -> t
@@ -80,6 +84,8 @@ module type Hash =
 
     val init : unit -> ctx
     val feed : ctx -> buffer -> int -> int -> unit
+    val feed_bytes : ctx -> By.t -> int -> int -> unit
+    val feed_bigstring : ctx -> Bi.t -> int -> int -> unit
     val get  : ctx -> buffer
   end with type buffer = Buffer.buffer
 
@@ -96,6 +102,10 @@ struct
 
     let feed ctx buf =
       feed ctx buf 0 (Bi.length buf)
+    let feed_bytes ctx buf =
+      feed_bytes ctx buf 0 (By.length buf)
+    let feed_bigstring ctx buf =
+      feed_bigstring ctx buf 0 (Bi.length buf)
 
     let digest buf =
       let t = init () in ( feed t buf; get t)
@@ -112,6 +122,10 @@ struct
 
     let feed ctx buf =
       feed ctx buf 0 (By.length buf)
+    let feed_bytes ctx buf =
+      feed_bytes ctx buf 0 (By.length buf)
+    let feed_bigstring ctx buf =
+      feed_bigstring ctx buf 0 (Bi.length buf)
 
     let digest buf =
       let t = init () in ( feed t buf; get t)
@@ -198,6 +212,8 @@ module type Hash' =
     val init : unit -> ctx
     val init': buffer -> int -> int -> ctx
     val feed : ctx -> buffer -> int -> int -> unit
+    val feed_bytes : ctx -> By.t -> int -> int -> unit
+    val feed_bigstring : ctx -> Bi.t -> int -> int -> unit
     val get  : ctx -> buffer
   end with type buffer = Buffer.buffer
 
@@ -213,6 +229,10 @@ struct
 
     let feed ctx buf =
       feed ctx buf 0 (By.length buf)
+    let feed_bytes ctx buf =
+      feed_bytes ctx buf 0 (By.length buf)
+    let feed_bigstring ctx buf =
+      feed_bigstring ctx buf 0 (Bi.length buf)
 
     let digest buf =
       let t = init () in ( feed t buf; get t)
@@ -237,6 +257,10 @@ struct
 
     let feed ctx buf =
       feed ctx buf 0 (Bi.length buf)
+    let feed_bytes ctx buf =
+      feed_bytes ctx buf 0 (By.length buf)
+    let feed_bigstring ctx buf =
+      feed_bigstring ctx buf 0 (Bi.length buf)
 
     let digest buf =
       let t = init () in ( feed t buf; get t)

--- a/test/test.ml
+++ b/test/test.ml
@@ -61,7 +61,7 @@ let test
       atest (module Bi) hash Digestif.Bigstring.mac key input expect
 
 let make
-  : type a. name:string -> a buffer -> Digestif.hash -> a -> a -> a -> Alcotest.test_case
+  : type a. name:string -> a buffer -> Digestif.hash -> a -> a -> a -> unit Alcotest.test_case
   = fun ~name buffer hash key input expect ->
     name, `Slow, (fun () -> test buffer hash key input expect)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -181,12 +181,19 @@ let results_blake2b_by, results_blake2b_bi =
 
 let tests () =
   Alcotest.run "digestif"
-    [ "md5",     makes ~name:"md5"     bytes `MD5     keys_by inputs_by results_md5_by
-    ; "sha1",    makes ~name:"sha1"    bytes `SHA1    keys_by inputs_by results_sha1_by
-    ; "sha224",  makes ~name:"sha224"  bytes `SHA224  keys_by inputs_by results_sha224_by
-    ; "sha256",  makes ~name:"sha256"  bytes `SHA256  keys_by inputs_by results_sha256_by
-    ; "sha384",  makes ~name:"sha384"  bytes `SHA384  keys_by inputs_by results_sha384_by
-    ; "sha512",  makes ~name:"sha512"  bytes `SHA512  keys_by inputs_by results_sha512_by
-    ; "blake2b", makes ~name:"blake2b" bytes `BLAKE2B keys_by inputs_by results_blake2b_by ]
+    [ "md5",                 makes ~name:"md5"     bytes     `MD5     keys_by inputs_by results_md5_by
+    ; "md5 (bigstring)",     makes ~name:"md5"     bigstring `MD5     keys_bi inputs_bi results_md5_bi
+    ; "sha1",                makes ~name:"sha1"    bytes     `SHA1    keys_by inputs_by results_sha1_by
+    ; "sha1 (bigstring)",    makes ~name:"sha1"    bigstring `SHA1    keys_bi inputs_bi results_sha1_bi
+    ; "sha224",              makes ~name:"sha224"  bytes     `SHA224  keys_by inputs_by results_sha224_by
+    ; "sha224 (bigstring)",  makes ~name:"sha224"  bigstring `SHA224  keys_bi inputs_bi results_sha224_bi
+    ; "sha256",              makes ~name:"sha256"  bytes     `SHA256  keys_by inputs_by results_sha256_by
+    ; "sha256 (bigstring)",  makes ~name:"sha256"  bigstring `SHA256  keys_bi inputs_bi results_sha256_bi
+    ; "sha384",              makes ~name:"sha384"  bytes     `SHA384  keys_by inputs_by results_sha384_by
+    ; "sha384 (bigstring)",  makes ~name:"sha384"  bigstring `SHA384  keys_bi inputs_bi results_sha384_bi
+    ; "sha512",              makes ~name:"sha512"  bytes     `SHA512  keys_by inputs_by results_sha512_by
+    ; "sha512 (bigstring)",  makes ~name:"sha512"  bigstring `SHA512  keys_bi inputs_bi results_sha512_bi
+    ; "blake2b",             makes ~name:"blake2b" bytes     `BLAKE2B keys_by inputs_by results_blake2b_by
+    ; "blake2b (bigstring)", makes ~name:"blake2b" bigstring `BLAKE2B keys_bi inputs_bi results_blake2b_bi ]
 
 let () = tests ()


### PR DESCRIPTION
Provide:

```ocaml
val feed_bytes : ctx -> Bytes.t -> unit
val feed_bigstring : ctx -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
```

For `Digestif.{Bytes.Bigstring}`. That means a `ctx` can feed a `bytes` or a `bigstring` independently the type of the result.

I add a test about the bigstring too.