### PR TITLE
Build tests

### DIFF
--- a/_tags
+++ b/_tags
@@ -4,4 +4,5 @@ true: safe_string, bin_annot
 <src-c/digestif.{cma,cmxa}>: record_digestif_rakia_stubs
 <src-c/digestif.cmxs>: link_digestif_rakia_stubs, use_bigarray
 <src-ocaml/digestif.cmxs>: use_bigarray
-<test/*.{ml,mli,byte,native}>: package(alcotest)
+"src-ocaml": include
+<test/*.{ml,mli,byte,native}>: package(alcotest bigarray)

--- a/opam
+++ b/opam
@@ -16,6 +16,8 @@ depends: [
   "ocamlbuild"     {build}
   "ocamlfind"      {build}
   "topkg"          {build}
+  "alcotest"       {test}
+  "fmt"            {test}
   "base-bytes"
 ]
 

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -17,4 +17,6 @@ let () =
 
      ; Pkg.clib "src-c/librakia_stubs.clib" ~lib_dst_dir:"c"
      ; Pkg.mllib ~api:["Digestif"] "src-c/digestif.mllib" ~dst_dir:"c"
-     ; Pkg.mllib ~api:["Digestif"] "src-ocaml/digestif.mllib" ~dst_dir:"ocaml" ]
+     ; Pkg.mllib ~api:["Digestif"] "src-ocaml/digestif.mllib" ~dst_dir:"ocaml"
+     ; Pkg.test "test/test"
+     ]


### PR DESCRIPTION
I started trying to add test vectors for SHA (from FIPS/NIST), BLAKE2B, etc, but the way the test suite is currently structured does not make it easy to add a test vector for a specific hash. Anyway, this PR makes topkg build the test at least.

Here are the vectors I collected (just so they can be found again if someone ever wants to integrate them).

- NIST's: https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
- blake2b: https://github.com/BLAKE2/BLAKE2/blob/master/testvectors/blake2b-kat.txt
- ripemd160: http://homes.esat.kuleuven.be/~bosselae/ripemd160.html#Outline