### PR TITLE
Blake2x final

### DIFF
--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -305,7 +305,7 @@ end
 
 module MakeBLAKE2S (D : sig val digest_size : int end) : S =
 struct
-  include Make_common_BLAKE2(Native.BLAKE2B)(struct let (digest_size, block_size) = (D.digest_size, 64) end)
+  include Make_common_BLAKE2(Native.BLAKE2S)(struct let (digest_size, block_size) = (D.digest_size, 64) end)
 end
 
 type 'a hash = 'a Digestif_sig.hash

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -162,32 +162,37 @@ module Make (F : Foreign) (D : Desc) = struct
   end
 end
 
-module type ForeignExt = sig
+(* XXX(dinosaure): this interface provide a new function to set digest size and
+   key. See #20. *)
+module type ForeignBLAKE2 = sig
   open Native
 
   module Bigstring :
   sig
-    val init     : ctx -> unit
-    val init'    : ctx -> int -> ba -> int -> int -> unit
-    val update   : ctx -> ba -> int -> int -> unit
-    val finalize : ctx -> ba -> int -> unit
+    val init      : ctx -> unit
+    val update    : ctx -> ba -> int -> int -> unit
+    val finalize  : ctx -> ba -> int -> unit
+    val with_outlen_and_key : ctx -> int -> ba -> int -> int -> unit
   end
 
   module Bytes :
   sig
-    val init     : ctx -> unit
-    val init'    : ctx -> int -> st -> int -> int -> unit
-    val update   : ctx -> st -> int -> int -> unit
-    val finalize : ctx -> st -> int -> unit
+    val init      : ctx -> unit
+    val update    : ctx -> st -> int -> int -> unit
+    val finalize  : ctx -> st -> int -> unit
+    val with_outlen_and_key : ctx -> int -> st -> int -> int -> unit
   end
 
-  val ctx_size   : unit -> int
-  val key_size   : unit -> int
+  val ctx_size    : unit -> int
+  val key_size    : unit -> int
+  val digest_size : ctx -> int
 end
 
-module Make_BLAKE2 (F : ForeignExt) (D : Desc) : Digestif_sig.S = struct
+module Make_common_BLAKE2 (F : ForeignBLAKE2) (D : Desc) : Digestif_sig.S = struct
   let block_size  = D.block_size
-  and digest_size = D.digest_size
+  and digest_size = D.digest_size (* XXX(dinosaure): short-cut [digest_size], we
+                                     use [D.digest_size] when we call
+                                     [F.with_outlen_and_key]. *)
   and ctx_size    = F.ctx_size ()
   and key_size    = F.key_size ()
 
@@ -201,7 +206,7 @@ module Make_BLAKE2 (F : ForeignExt) (D : Desc) : Digestif_sig.S = struct
 
     let init () =
       let t = Bi.create ctx_size in
-      ( F.Bytes.init' t digest_size By.empty 0 0; t )
+      ( F.Bytes.with_outlen_and_key t digest_size By.empty 0 0; t )
 
     let feed t buf =
       F.Bytes.update t buf 0 (By.length buf)
@@ -223,9 +228,12 @@ module Make_BLAKE2 (F : ForeignExt) (D : Desc) : Digestif_sig.S = struct
       let t = init () in ( List.iter (feed t) bufs; get t )
 
     let hmacv ~key msg =
+      if By.length key > key_size
+      then raise (Invalid_argument "BLAKE2{B,S}.hmac{v}: invalid key");
+
       let ctx = Bi.create ctx_size in
       let res = By.create digest_size in
-      F.Bytes.init' ctx digest_size key 0 (By.length key);
+      F.Bytes.with_outlen_and_key ctx digest_size key 0 (By.length key);
       List.iter (fun x -> F.Bytes.update ctx x 0 (By.length x)) msg;
       F.Bytes.finalize ctx res 0;
       res
@@ -243,7 +251,7 @@ module Make_BLAKE2 (F : ForeignExt) (D : Desc) : Digestif_sig.S = struct
 
     let init () =
       let t = Bi.create ctx_size in
-      ( F.Bigstring.init' t digest_size Bi.empty 0 0; t )
+      ( F.Bigstring.with_outlen_and_key t digest_size Bi.empty 0 0; t )
 
     let feed t buf =
       F.Bigstring.update t buf 0 (Bi.length buf)
@@ -266,11 +274,11 @@ module Make_BLAKE2 (F : ForeignExt) (D : Desc) : Digestif_sig.S = struct
 
     let hmacv ~key msg =
       if Bi.length key > key_size
-      then raise (Invalid_argument "BLAKE2B.hmac{v}: invalid key");
+      then raise (Invalid_argument "BLAKE2{B,S}.hmac{v}: invalid key");
 
       let ctx = Bi.create ctx_size in
       let res = Bi.create digest_size in
-      F.Bigstring.init' ctx digest_size key 0 (Bi.length key);
+      F.Bigstring.with_outlen_and_key ctx digest_size key 0 (Bi.length key);
       List.iter (fun x -> F.Bigstring.update ctx x 0 (Bi.length x)) msg;
       F.Bigstring.finalize ctx res 0;
       res
@@ -286,9 +294,19 @@ module SHA224  : S = Make (Native.SHA224) (struct let (digest_size, block_size) 
 module SHA256  : S = Make (Native.SHA256) (struct let (digest_size, block_size) = (32, 64) end)
 module SHA384  : S = Make (Native.SHA384) (struct let (digest_size, block_size) = (48, 128) end)
 module SHA512  : S = Make (Native.SHA512) (struct let (digest_size, block_size) = (64, 128) end)
-module BLAKE2B = Make_BLAKE2(Native.BLAKE2B) (struct let (digest_size, block_size) = (64, 128) end)
-module BLAKE2S = Make_BLAKE2(Native.BLAKE2S) (struct let (digest_size, block_size) = (32, 64) end)
+module BLAKE2B = Make_common_BLAKE2(Native.BLAKE2B) (struct let (digest_size, block_size) = (64, 128) end)
+module BLAKE2S = Make_common_BLAKE2(Native.BLAKE2S) (struct let (digest_size, block_size) = (32, 64) end)
 module RMD160  : S = Make (Native.RMD160) (struct let (digest_size, block_size) = (20, 64) end)
+
+module MakeBLAKE2B (D : sig val digest_size : int end) : S =
+struct
+  include Make_common_BLAKE2(Native.BLAKE2B)(struct let (digest_size, block_size) = (D.digest_size, 128) end)
+end
+
+module MakeBLAKE2S (D : sig val digest_size : int end) : S =
+struct
+  include Make_common_BLAKE2(Native.BLAKE2B)(struct let (digest_size, block_size) = (D.digest_size, 64) end)
+end
 
 type hash = Digestif_sig.hash
 

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -308,7 +308,7 @@ struct
   include Make_common_BLAKE2(Native.BLAKE2S)(struct let (digest_size, block_size) = (D.digest_size, 64) end)
 end
 
-type 'a hash = 'a Digestif_sig.hash
+include Digestif_hash
 
 let module_of :
   type a. a hash -> (module S) = fun hash ->

--- a/src-c/digestif.mli
+++ b/src-c/digestif.mli
@@ -15,6 +15,9 @@ module BLAKE2B : S
 module BLAKE2S : S
 module RMD160  : S
 
+module MakeBLAKE2B(D : sig val digest_size : int end) : S
+module MakeBLAKE2S(D : sig val digest_size : int end) : S
+
 module Bytes : T
   with type t = Bytes.t
    and type buffer = Bytes.t

--- a/src-c/digestif.mli
+++ b/src-c/digestif.mli
@@ -1,9 +1,9 @@
 module type S = Digestif_sig.S
 module type T = Digestif_sig.T
 
-type hash = Digestif_sig.hash
+type 'a hash = 'a Digestif_sig.hash
 
-val digest_size : hash -> int
+val digest_size : _ hash -> int
 
 module MD5     : S
 module SHA1    : S

--- a/src-c/digestif.mli
+++ b/src-c/digestif.mli
@@ -3,6 +3,8 @@ module type T = Digestif_sig.T
 
 type 'a hash = 'a Digestif_sig.hash
 
+include Digestif_sig.C
+
 val digest_size : _ hash -> int
 
 module MD5     : S

--- a/src-c/native/blake2b.c
+++ b/src-c/native/blake2b.c
@@ -174,7 +174,7 @@ void digestif_blake2b_update( struct blake2b_ctx *ctx, uint8_t *data, uint32_t i
   }
 }
 
-void digestif_blake2b_abstract_init(struct blake2b_ctx *ctx, size_t outlen, const void *key, size_t keylen)
+void digestif_blake2b_init_with_outlen_and_key(struct blake2b_ctx *ctx, size_t outlen, const void *key, size_t keylen)
 {
   struct blake2b_param P[1];
   const unsigned char * p = ( const uint8_t * )( P );

--- a/src-c/native/blake2b.h
+++ b/src-c/native/blake2b.h
@@ -49,7 +49,7 @@ PACKED(struct blake2b_param
 #define BLAKE2B_CTX_SIZE    (sizeof(struct blake2b_ctx))
 
 void digestif_blake2b_init(struct blake2b_ctx *ctx);
-void digestif_blake2b_abstract_init(struct blake2b_ctx *ctx, size_t outlen, const void *key, size_t keylen);
+void digestif_blake2b_init_with_outlen_and_key(struct blake2b_ctx *ctx, size_t outlen, const void *key, size_t keylen);
 void digestif_blake2b_update(struct blake2b_ctx *ctx, uint8_t *data, uint32_t len);
 void digestif_blake2b_finalize(struct blake2b_ctx *ctx, uint8_t *out);
 

--- a/src-c/native/blake2s.c
+++ b/src-c/native/blake2s.c
@@ -167,7 +167,7 @@ void digestif_blake2s_update( struct blake2s_ctx *ctx, uint8_t *data, uint32_t i
   }
 }
 
-void digestif_blake2s_abstract_init(struct blake2s_ctx *ctx, size_t outlen, const void *key, size_t keylen)
+void digestif_blake2s_init_with_outlen_and_key(struct blake2s_ctx *ctx, size_t outlen, const void *key, size_t keylen)
 {
   struct blake2s_param P[1];
   const unsigned char * p = ( const uint8_t * )( P );

--- a/src-c/native/blake2s.h
+++ b/src-c/native/blake2s.h
@@ -48,7 +48,7 @@ PACKED(struct blake2s_param
 #define BLAKE2S_CTX_SIZE    (sizeof(struct blake2s_ctx))
 
 void digestif_blake2s_init(struct blake2s_ctx *ctx);
-void digestif_blake2s_abstract_init(struct blake2s_ctx *ctx, size_t outlen, const void *key, size_t keylen);
+void digestif_blake2s_init_with_outlen_and_key(struct blake2s_ctx *ctx, size_t outlen, const void *key, size_t keylen);
 void digestif_blake2s_update(struct blake2s_ctx *ctx, uint8_t *data, uint32_t len);
 void digestif_blake2s_finalize(struct blake2s_ctx *ctx, uint8_t *out);
 

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -70,9 +70,9 @@ __define_hash (blake2s, BLAKE2S)
 __define_hash (rmd160, RMD160)
 
 CAMLprim value
-caml_digestif_blake2b_ba_abstract_init(value ctx, value outlen, value key, value off, value len)
+caml_digestif_blake2b_ba_init_with_outlen_and_key(value ctx, value outlen, value key, value off, value len)
 {
-  digestif_blake2b_abstract_init(
+  digestif_blake2b_init_with_outlen_and_key(
     (struct blake2b_ctx *) Caml_ba_data_val (ctx), Int_val (outlen),
     _ba_uint8_off(key, off), Int_val (len));
 
@@ -80,9 +80,9 @@ caml_digestif_blake2b_ba_abstract_init(value ctx, value outlen, value key, value
 }
 
 CAMLprim value
-caml_digestif_blake2b_st_abstract_init(value ctx, value outlen, value key, value off, value len)
+caml_digestif_blake2b_st_init_with_outlen_and_key(value ctx, value outlen, value key, value off, value len)
 {
-  digestif_blake2b_abstract_init(
+  digestif_blake2b_init_with_outlen_and_key(
     (struct blake2b_ctx *) Caml_ba_data_val (ctx), Int_val (outlen),
     _st_uint8_off(key, off), Int_val (len));
 
@@ -100,9 +100,9 @@ caml_digestif_blake2b_digest_size(value ctx) {
 }
 
 CAMLprim value
-caml_digestif_blake2s_ba_abstract_init(value ctx, value outlen, value key, value off, value len)
+caml_digestif_blake2s_ba_init_with_outlen_and_key(value ctx, value outlen, value key, value off, value len)
 {
-  digestif_blake2s_abstract_init(
+  digestif_blake2s_init_with_outlen_and_key(
     (struct blake2s_ctx *) Caml_ba_data_val (ctx), Int_val (outlen),
     _ba_uint8_off(key, off), Int_val (len));
 
@@ -110,9 +110,9 @@ caml_digestif_blake2s_ba_abstract_init(value ctx, value outlen, value key, value
 }
 
 CAMLprim value
-caml_digestif_blake2s_st_abstract_init(value ctx, value outlen, value key, value off, value len)
+caml_digestif_blake2s_st_init_with_outlen_and_key(value ctx, value outlen, value key, value off, value len)
 {
-  digestif_blake2s_abstract_init(
+  digestif_blake2s_init_with_outlen_and_key(
     (struct blake2s_ctx *) Caml_ba_data_val (ctx), Int_val (outlen),
     _st_uint8_off(key, off), Int_val (len));
 

--- a/src-c/rakia_native.ml
+++ b/src-c/rakia_native.ml
@@ -264,7 +264,7 @@ struct
   external digest_size : ctx -> int
                        = "caml_digestif_blake2b_digest_size"
                        [@@noalloc]
-                     end
+end
 
 module BLAKE2S =
 struct

--- a/src-c/rakia_native.ml
+++ b/src-c/rakia_native.ml
@@ -226,14 +226,14 @@ struct
     external init     : ctx -> unit
                       = "caml_digestif_blake2b_ba_init"
                       [@@noalloc]
-    external init'    : ctx -> size -> ba -> off -> size -> unit
-                      = "caml_digestif_blake2b_ba_abstract_init"
-                      [@@noalloc]
     external update   : ctx -> ba -> off -> size -> unit
                       = "caml_digestif_blake2b_ba_update"
                       [@@noalloc]
     external finalize : ctx -> ba -> off -> unit
                       = "caml_digestif_blake2b_ba_finalize"
+                      [@@noalloc]
+    external with_outlen_and_key : ctx -> size -> ba -> off -> size -> unit
+                      = "caml_digestif_blake2b_ba_init_with_outlen_and_key"
                       [@@noalloc]
   end
 
@@ -242,14 +242,14 @@ struct
     external init     : ctx -> unit
                       = "caml_digestif_blake2b_st_init"
                       [@@noalloc]
-    external init'    : ctx -> size -> st -> off -> size -> unit
-                      = "caml_digestif_blake2b_st_abstract_init"
-                      [@@noalloc]
     external update   : ctx -> st -> off -> size -> unit
                       = "caml_digestif_blake2b_st_update"
                       [@@noalloc]
     external finalize : ctx -> st -> off -> unit
                       = "caml_digestif_blake2b_st_finalize"
+                      [@@noalloc]
+    external with_outlen_and_key : ctx -> size -> st -> off -> size -> unit
+                      = "caml_digestif_blake2b_st_init_with_outlen_and_key"
                       [@@noalloc]
   end
 
@@ -273,14 +273,14 @@ struct
     external init     : ctx -> unit
                       = "caml_digestif_blake2s_ba_init"
                       [@@noalloc]
-    external init'    : ctx -> size -> ba -> off -> size -> unit
-                      = "caml_digestif_blake2s_ba_abstract_init"
-                      [@@noalloc]
     external update   : ctx -> ba -> off -> size -> unit
                       = "caml_digestif_blake2s_ba_update"
                       [@@noalloc]
     external finalize : ctx -> ba -> off -> unit
                       = "caml_digestif_blake2s_ba_finalize"
+                      [@@noalloc]
+    external with_outlen_and_key : ctx -> size -> ba -> off -> size -> unit
+                      = "caml_digestif_blake2s_ba_init_with_outlen_and_key"
                       [@@noalloc]
   end
 
@@ -289,14 +289,14 @@ struct
     external init     : ctx -> unit
                       = "caml_digestif_blake2s_st_init"
                       [@@noalloc]
-    external init'    : ctx -> size -> st -> off -> size -> unit
-                      = "caml_digestif_blake2s_st_abstract_init"
-                      [@@noalloc]
     external update   : ctx -> st -> off -> size -> unit
                       = "caml_digestif_blake2s_st_update"
                       [@@noalloc]
     external finalize : ctx -> st -> off -> unit
                       = "caml_digestif_blake2s_st_finalize"
+                      [@@noalloc]
+    external with_outlen_and_key : ctx -> size -> st -> off -> size -> unit
+                      = "caml_digestif_blake2s_st_init_with_outlen_and_key"
                       [@@noalloc]
   end
 

--- a/src-ocaml/baijiu_blake2b.ml
+++ b/src-ocaml/baijiu_blake2b.ml
@@ -68,7 +68,7 @@ module Make (B : Baijiu_buffer.S)
 
   type ctx =
     { mutable buflen    : int
-    ; mutable outlen    : int
+    ; outlen            : int
     ; mutable last_node : int
     ; buf               : buffer
     ; h                 : int64 array

--- a/src-ocaml/baijiu_blake2s.ml
+++ b/src-ocaml/baijiu_blake2s.ml
@@ -42,7 +42,7 @@ sig
   type buffer
 
   val init : unit -> ctx
-  val init': buffer -> int -> int -> ctx
+  val with_outlen_and_key : int -> buffer -> int -> int -> ctx
   val feed : ctx -> buffer -> int -> int -> unit
   val feed_bytes : ctx -> Bytes.t -> int -> int -> unit
   val feed_bigstring : ctx -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t -> int -> int -> unit
@@ -299,14 +299,14 @@ module Make (B : Baijiu_buffer.S)
   let feed_bigstring = feed ~blit:B.blit_from_bigstring ~le32_to_cpu:B.le32_from_bigstring_to_cpu
   let feed = feed ~blit:B.blit ~le32_to_cpu:B.le32_to_cpu
 
-  let init' key off len =
+  let with_outlen_and_key outlen key off len =
     let buf = B.create 64 in
 
     B.fill buf 0 64 '\x00';
 
     let ctx =
       { buflen = 0
-      ; outlen = default_param.digest_length
+      ; outlen
       ; last_node = 0
       ; buf
       ; h = Array.make 8 0l
@@ -314,7 +314,9 @@ module Make (B : Baijiu_buffer.S)
       ; f = Array.make 2 0l }
     in
 
-    let param_bytes = param_to_bytes { default_param with key_length = len } in
+    let param_bytes = param_to_bytes
+        { default_param with key_length = len
+                           ; digest_length = outlen } in
 
     for i = 0 to 7
     do ctx.h.(i) <- Int32.(iv.(i) lxor (B.le32_to_cpu param_bytes (i * 4))) done;
@@ -342,5 +344,5 @@ module Make (B : Baijiu_buffer.S)
     for i = 0 to 7
     do B.cpu_to_le32 res (i * 4) ctx.h.(i) done;
 
-    res
+    B.sub res 0 ctx.outlen
 end

--- a/src-ocaml/baijiu_blake2s.ml
+++ b/src-ocaml/baijiu_blake2s.ml
@@ -67,7 +67,7 @@ module Make (B : Baijiu_buffer.S)
 
   type ctx =
     { mutable buflen    : int
-    ; mutable outlen    : int
+    ; outlen            : int
     ; mutable last_node : int
     ; buf               : buffer
     ; h                 : int32 array

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -137,21 +137,6 @@ struct
   end
 end
 
-module NI (B : BUFFER) =
-struct
-  let not_implemented () = raise (Failure "Not implemented")
-
-  type t = B.buffer
-  type buffer = B.buffer
-  type ctx = unit
-
-  let init = not_implemented
-  let feed ctx buf = not_implemented ()
-  let feed_bytes ctx buf = not_implemented ()
-  let feed_bigstring ctx buf = not_implemented ()
-  let get ctx = not_implemented ()
-end
-
 module type HashBLAKE2 =
   functor (Buffer : BUFFER) -> sig
     type ctx
@@ -234,13 +219,6 @@ struct
     let hmac ~key msg =
       hmacv ~key [ msg ]
   end
-end
-
-
-module DI =
-struct
-  let digest_size = 0
-  let block_size = 0
 end
 
 module MD5     : S = Make (Baijiu_md5.Make) (struct let (digest_size, block_size) = (16, 64) end)

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -241,7 +241,7 @@ struct
   include Make_BLAKE2(Baijiu_blake2s.Make)(struct let (digest_size, block_size) = (D.digest_size, 64) end)
 end
 
-type 'a hash = 'a Digestif_sig.hash
+include Digestif_hash
 
 let module_of :
   type a. a hash -> (module S) = fun hash ->

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -241,27 +241,36 @@ struct
   include Make_BLAKE2(Baijiu_blake2s.Make)(struct let (digest_size, block_size) = (D.digest_size, 64) end)
 end
 
-type hash =
-  [ `MD5
-  | `SHA1
-  | `SHA224
-  | `SHA256
-  | `SHA384
-  | `SHA512
-  | `BLAKE2B
-  | `BLAKE2S
-  | `RMD160 ]
+type 'a hash = 'a Digestif_sig.hash
 
-let module_of = function
-  | `MD5     -> (module MD5     : S)
-  | `SHA1    -> (module SHA1    : S)
-  | `SHA224  -> (module SHA224  : S)
-  | `SHA256  -> (module SHA256  : S)
-  | `SHA384  -> (module SHA384  : S)
-  | `SHA512  -> (module SHA512  : S)
-  | `BLAKE2B -> (module BLAKE2B : S)
-  | `BLAKE2S -> (module BLAKE2S : S)
-  | `RMD160  -> (module RMD160  : S)
+let module_of :
+  type a. a hash -> (module S) = fun hash ->
+  let b2b = Hashtbl.create 13 in
+  let b2s = Hashtbl.create 13 in
+  match hash with
+  | Digestif_sig.MD5     -> (module MD5     : S)
+  | Digestif_sig.SHA1    -> (module SHA1    : S)
+  | Digestif_sig.RMD160  -> (module RMD160  : S)
+  | Digestif_sig.SHA224  -> (module SHA224  : S)
+  | Digestif_sig.SHA256  -> (module SHA256  : S)
+  | Digestif_sig.SHA384  -> (module SHA384  : S)
+  | Digestif_sig.SHA512  -> (module SHA512  : S)
+  | Digestif_sig.BLAKE2B digest_size -> begin
+      match Hashtbl.find b2b digest_size with
+      | exception Not_found ->
+        let m = (module MakeBLAKE2B(struct let digest_size = digest_size end) : S) in
+        Hashtbl.replace b2b digest_size m ;
+        m
+      | m -> m
+    end
+  | Digestif_sig.BLAKE2S digest_size -> begin
+      match Hashtbl.find b2s digest_size with
+      | exception Not_found ->
+        let m = (module MakeBLAKE2S(struct let digest_size = digest_size end) : S) in
+        Hashtbl.replace b2s digest_size m ;
+        m
+      | m -> m
+    end
 
 module Bytes =
 struct

--- a/src-ocaml/digestif.mli
+++ b/src-ocaml/digestif.mli
@@ -3,6 +3,8 @@ module type T = Digestif_sig.T
 
 type 'a hash = 'a Digestif_sig.hash
 
+include Digestif_sig.C
+
 val digest_size : 'a hash -> int
 
 module MD5     : S

--- a/src-ocaml/digestif.mli
+++ b/src-ocaml/digestif.mli
@@ -1,9 +1,9 @@
 module type S = Digestif_sig.S
 module type T = Digestif_sig.T
 
-type hash = Digestif_sig.hash
+type 'a hash = 'a Digestif_sig.hash
 
-val digest_size : hash -> int
+val digest_size : 'a hash -> int
 
 module MD5     : S
 module SHA1    : S

--- a/src-ocaml/digestif.mli
+++ b/src-ocaml/digestif.mli
@@ -15,6 +15,9 @@ module BLAKE2B : S
 module BLAKE2S : S
 module RMD160  : S
 
+module MakeBLAKE2B (D : sig val digest_size : int end) : S
+module MakeBLAKE2S (D : sig val digest_size : int end) : S
+
 module Bytes : T
   with type t = Bytes.t
    and type buffer = Bytes.t

--- a/src/digestif.mllib
+++ b/src/digestif.mllib
@@ -1,3 +1,4 @@
 Digestif_pp
 Digestif_bytes
 Digestif_bigstring
+Digestif_hash

--- a/src/digestif_hash.ml
+++ b/src/digestif_hash.ml
@@ -1,0 +1,14 @@
+open Digestif_sig
+
+type nonrec 'a hash = 'a hash
+and nothing = nothing
+
+let md5 = MD5
+let sha1 = SHA1
+let rmd160 = RMD160
+let sha224 = SHA224
+let sha256 = SHA256
+let sha384 = SHA384
+let sha512 = SHA512
+let blake2b length = BLAKE2B length
+let blake2s length = BLAKE2S length

--- a/src/digestif_hash.mli
+++ b/src/digestif_hash.mli
@@ -1,0 +1,5 @@
+type 'a hash = 'a Digestif_sig.hash
+and nothing = Digestif_sig.nothing
+
+include Digestif_sig.C
+

--- a/src/digestif_sig.mli
+++ b/src/digestif_sig.mli
@@ -57,15 +57,28 @@ module type S = sig
 end
 
 type _ hash =
-  | MD5 : unit hash
-  | SHA1 : unit hash
-  | RMD160 : unit hash
-  | SHA224 : unit hash
-  | SHA256 : unit hash
-  | SHA384 : unit hash
-  | SHA512 : unit hash
+  | MD5     : nothing hash
+  | SHA1    : nothing hash
+  | RMD160  : nothing hash
+  | SHA224  : nothing hash
+  | SHA256  : nothing hash
+  | SHA384  : nothing hash
+  | SHA512  : nothing hash
   | BLAKE2B : int -> int hash
   | BLAKE2S : int -> int hash
+and nothing = unit
+
+module type C = sig
+  val md5     : nothing hash
+  val sha1    : nothing hash
+  val rmd160  : nothing hash
+  val sha224  : nothing hash
+  val sha256  : nothing hash
+  val sha384  : nothing hash
+  val sha512  : nothing hash
+  val blake2b : int -> int hash
+  val blake2s : int -> int hash
+end
 
 module type T = sig
   type t

--- a/src/digestif_sig.mli
+++ b/src/digestif_sig.mli
@@ -56,26 +56,26 @@ module type S = sig
   end
 end
 
-type hash =
-  [ `MD5
-  | `SHA1
-  | `SHA224
-  | `SHA256
-  | `SHA384
-  | `SHA512
-  | `BLAKE2B
-  | `BLAKE2S
-  | `RMD160 ]
+type _ hash =
+  | MD5 : unit hash
+  | SHA1 : unit hash
+  | RMD160 : unit hash
+  | SHA224 : unit hash
+  | SHA256 : unit hash
+  | SHA384 : unit hash
+  | SHA512 : unit hash
+  | BLAKE2B : int -> int hash
+  | BLAKE2S : int -> int hash
 
 module type T = sig
   type t
   type buffer
 
-  val pp      : hash -> Format.formatter -> t -> unit
-  val digest  : hash -> buffer -> t
-  val digestv : hash -> buffer list -> t
-  val mac     : hash -> key:buffer -> buffer -> t
-  val macv    : hash -> key:buffer -> buffer list -> t
-  val of_hex  : hash -> buffer -> t
-  val to_hex  : hash -> t -> buffer
+  val pp      : _ hash -> Format.formatter -> t -> unit
+  val digest  : _ hash -> buffer -> t
+  val digestv : _ hash -> buffer list -> t
+  val mac     : _ hash -> key:buffer -> buffer -> t
+  val macv    : _ hash -> key:buffer -> buffer list -> t
+  val of_hex  : _ hash -> buffer -> t
+  val to_hex  : _ hash -> t -> buffer
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -8,16 +8,7 @@ sig
   val pp : t Fmt.t
 end
 
-let title = function
-  | `MD5     -> "hmac:md5"
-  | `SHA1    -> "hmac:sha1"
-  | `SHA224  -> "hmac:sha224"
-  | `SHA256  -> "hmac:sha256"
-  | `SHA384  -> "hmac:sha384"
-  | `SHA512  -> "hmac:sha512"
-  | `BLAKE2B -> "hmac:blake2b"
-  | `BLAKE2S -> "hmac:blake2s"
-  | `RMD160  -> "hmac:rmd160"
+let title _ = "hmac"
 
 type _ buffer =
   | Bytes : Bytes.t buffer
@@ -39,7 +30,7 @@ let btest (type buffer) (module Buffer : S with type t = buffer) hash digest (in
 
   Alcotest.(check (Alcotest.testable Buffer.pp Buffer.eq)) title expect result
 
-module type HASH = sig type t = Digestif.hash val v : t end
+module type HASH = sig type 'a t = 'a Digestif.hash type hash val v : hash t end
 
 module By (Hash : HASH) =
 struct
@@ -58,34 +49,34 @@ struct
 end
 
 let test
-  : type a. a buffer -> Digestif.hash -> a -> a -> a -> unit
+  : type a h. a buffer -> h Digestif.hash -> a -> a -> a -> unit
   = fun buffer hash key input expect ->
     match buffer with
     | Bytes ->
-      let module By = By(struct type t = Digestif.hash let v = hash end) in
+      let module By = By(struct type 'hash t = 'hash Digestif.hash type hash = h let v = hash end) in
       atest (module By) hash Digestif.Bytes.mac key input expect
     | Bigstring ->
-      let module Bi = Bi(struct type t = Digestif.hash let v = hash end) in
+      let module Bi = Bi(struct type 'hash t = 'hash Digestif.hash type hash = h let v = hash end) in
       atest (module Bi) hash Digestif.Bigstring.mac key input expect
 
 let test_digest
-  : type a. a buffer -> Digestif.hash -> a -> a -> unit
+  : type a h. a buffer -> h Digestif.hash -> a -> a -> unit
   = fun buffer hash input expect ->
     match buffer with
     | Bytes ->
-      let module By = By(struct type t = Digestif.hash let v = hash end) in
+      let module By = By(struct type 'hash t = 'hash Digestif.hash type hash = h let v = hash end) in
       btest (module By) hash Digestif.Bytes.digest input expect
     | Bigstring ->
-      let module Bi = Bi(struct type t = Digestif.hash let v = hash end) in
+      let module Bi = Bi(struct type 'hash t = 'hash Digestif.hash type hash = h let v = hash end) in
       btest (module Bi) hash Digestif.Bigstring.digest input expect
 
 let make
-  : type a. name:string -> a buffer -> Digestif.hash -> a -> a -> a -> unit Alcotest.test_case
+  : type a. name:string -> a buffer -> 'hash Digestif.hash -> a -> a -> a -> unit Alcotest.test_case
   = fun ~name buffer hash key input expect ->
     name, `Slow, (fun () -> test buffer hash key input expect)
 
 let make_digest
-  : type a. name:string -> a buffer -> Digestif.hash -> a -> a -> unit Alcotest.test_case
+  : type a. name:string -> a buffer -> 'hash Digestif.hash -> a -> a -> unit Alcotest.test_case
   = fun ~name buffer hash input expect ->
     name, `Slow, (fun () -> test_digest buffer hash input expect)
 
@@ -140,7 +131,7 @@ let results_md5_by, results_md5_bi =
   ; "1cdd24eef6163afee7adc7c53dd6c9df"
   ; "0316ebcad933675e84a81850e24d55b2"
   ; "9ee938a2659d546ccc2e5993601964eb" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `MD5)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.md5)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -150,7 +141,7 @@ let results_sha1_by, results_sha1_bi =
   ; "d80589525b1cc9f5e5ffd48ffd73d710ac89a3f1"
   ; "0a5212b295e11a1de5c71873e70ce54f45119516"
   ; "deaf6465e5945a0d04cba439c628ee9f47b95aef" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `SHA1)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.sha1)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -160,7 +151,7 @@ let results_sha224_by, results_sha224_bi =
   ; "b94a09654fc749ae6cb21c7765bf4938ff9af03e13d83fbf23342ce7"
   ; "7c66e4c7297a22ca80e2e1db9774afea64b1e086be366d2da3e6bc83"
   ; "438dc3311243cd54cc7ee24c9aac8528a1750abc595f06e68a331d2a" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `SHA224)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.sha224)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -170,7 +161,7 @@ let results_sha256_by, results_sha256_bi =
   ; "aa36cd61caddefe26b07ba1d3d07ea978ed575c9d1f921837dff9f73e019713e"
   ; "a7c8b53d68678a8e6e4d403c6b97cf0f82c4ef7b835c41039c0a73aa4d627d05"
   ; "b2a83b628f7e0da71c3879b81075775072d0d35935c62cc6c5a79b337ccccca1" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `SHA256)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.sha256)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -180,7 +171,7 @@ let results_sha384_by, results_sha384_bi =
   ; "bd3b5c82edcd0f206aadff7aa89dbbc3a7655844ffc9f8f9fa17c90eb36b13ec7828fba7252c3f5d90cff666ea44d557"
   ; "16461c2a44877c69fb38e4dce2edc822d68517917fc84d252de64132bd43c7cbe3310b7e8661741b7728000e8abf51e0"
   ; "2c3751d1dc792344514928fad94672a256cf2f66344e4df96b0cc4cc3f6800aa5a628e9becf5f65672e1acf013284893" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `SHA384)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.sha384)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -190,7 +181,7 @@ let results_sha512_by, results_sha512_bi =
   ; "c2f2077f538171d7c6cbee0c94948f82987117a50229fb0b48a534e3c63553a9a9704cdb460c597c8b46b631e49c22a9d2d46bded40f8a77652f754ec725e351"
   ; "89d7284e89642ec195f7a8ef098ef4e411fa3df17a07724cf13033bc6b7863968aad449cee973df9b92800d803ba3e14244231a86253cfacd1de882a542e945f"
   ; "f6ecfca37d2abcff4b362f1919629e784c4b618af77e1061bb992c11d7f518716f5df5978b0a1455d68ceeb10ced9251306d2f26181407be76a219d48c36b592" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `SHA512)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.sha512)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -200,7 +191,7 @@ let results_blake2b_by, results_blake2b_bi =
   ; "948194b8cffdafa5ceb8d56f02be0dee66014d5b8f7ca3536863334a498d073e2ef64c66e6933a2a3ae952aac4838a679fa49846133349f58cbd0db029ba0b3a"
   ; "c3a0eec1f5a3c60064e40de1b2ce0657edfde39ac23036350f4467ce1adf2756e5f7fd536b6d68646b48b26708649db1b25c3c98522b3ce532e2fd159b0d5f0e"
   ; "0b6cb224edfd69df745a102660c4629cc75c6ba25c342702815744d41434e75a451560d692dd64cec0fe5cace12385c807b4a6244cf1849c3566c3cc48d71e74" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `BLAKE2B)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex (Digestif.blake2b Digestif.BLAKE2B.digest_size))
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -210,7 +201,7 @@ let results_rmd160_by, results_rmd160_bi =
   ; "f071dcd2514fd89de78a5a2db1128dfa3e54d503"
   ; "bda5511e63389385218a8d902a70f2d8dc4dc074"
   ; "6c2486f169432281b6d71ae5b6765239c3cc1ea6" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `RMD160)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex Digestif.rmd160)
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -220,7 +211,7 @@ let results_blake2s_by, results_blake2s_bi =
   ; "88f53c94bf50819acd1d5db805c61fed44de72d58962802780b9972cf974274b"
   ; "af80be61a4103fc5daac2fe4b70125f146999850627d63a38aa416e59f237644"
   ; "e6a5a4794cd3421ad19f6e7621415bad773776859189c4d5173aed8677f93a31" ]
-  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex `BLAKE2S)
+  |> List.map (fun x -> Bytes.unsafe_of_string x |> Digestif.Bytes.of_hex (Digestif.blake2s Digestif.BLAKE2S.digest_size))
   |> List.map (fun s -> s, to_bigstring s)
   |> List.split
 
@@ -258,7 +249,7 @@ struct
                 then res
                 else (for i = i to len - 1 do Bytes.set res i '\000' done; res)
 
-  let parse (kind : [< `BLAKE2B | `BLAKE2S ]) ic =
+  let parse kind ic =
     ignore @@ input_line ic;
     ignore @@ input_line ic;
 
@@ -271,11 +262,11 @@ struct
         loop (`Key !i) acc
       | `Key i, line ->
         let k = ref empty in
-        Scanf.sscanf line "key:\t%s" (fun v -> k := of_hex (Digestif.digest_size (kind :> Digestif.hash)) v);
+        Scanf.sscanf line "key:\t%s" (fun v -> k := of_hex (Digestif.digest_size kind) v);
         loop (`Hash (i, !k)) acc
       | `Hash (i, k), line ->
         let h = ref empty in
-        Scanf.sscanf line "hash:\t%s" (fun v -> h := of_hex (Digestif.digest_size (kind :> Digestif.hash)) v);
+        Scanf.sscanf line "hash:\t%s" (fun v -> h := of_hex (Digestif.digest_size kind) v);
         loop (`Res (i, k, !h)) acc
       | `Res v, "" ->
         loop `In (v :: acc)
@@ -292,11 +283,11 @@ struct
 
     close_in ic;
     List.map
-      (fun (input, key, expect) -> make ~name:"blake2{b,s}" bytes (kind :> Digestif.hash) key input expect)
+      (fun (input, key, expect) -> make ~name:"blake2{b,s}" bytes kind key input expect)
       tests
 
-  let tests_blake2s = tests `BLAKE2S input_blake2s_file
-  let tests_blake2b = tests `BLAKE2B input_blake2b_file
+  let tests_blake2s = tests Digestif.(blake2s BLAKE2S.digest_size) input_blake2s_file
+  let tests_blake2b = tests Digestif.(blake2b BLAKE2B.digest_size) input_blake2b_file
 end
 
 module RMD160 =
@@ -358,7 +349,7 @@ struct
     let expect_million_y = BLAKE2.of_hex Digestif.RMD160.digest_size "52783243c1697bdbe16d37f97f68f08325dc1528" in
     let expect_million_i = to_bigstring expect_million_y in
 
-    List.map (fun (input, expect) -> make_digest ~name:"rmd160" Bytes `RMD160 input expect)
+    List.map (fun (input, expect) -> make_digest ~name:"rmd160" Bytes Digestif.rmd160 input expect)
       (List.combine (List.map Bytes.unsafe_of_string inputs) (List.map (BLAKE2.of_hex Digestif.RMD160.digest_size) expects))
     @ [ million "(bytes)" (module Digestif.RMD160.Bytes : D with type t = Bytes.t) (module By) ~expect:expect_million_y
       ; million "(bigstring)" (module Digestif.RMD160.Bigstring : D with type t = bigstring) (module Digestif_bigstring) ~expect:expect_million_i ]
@@ -366,24 +357,24 @@ end
 
 let tests () =
   Alcotest.run "digestif"
-    [ "md5",                 makes ~name:"md5"     bytes     `MD5     keys_by inputs_by results_md5_by
-    ; "md5 (bigstring)",     makes ~name:"md5"     bigstring `MD5     keys_bi inputs_bi results_md5_bi
-    ; "sha1",                makes ~name:"sha1"    bytes     `SHA1    keys_by inputs_by results_sha1_by
-    ; "sha1 (bigstring)",    makes ~name:"sha1"    bigstring `SHA1    keys_bi inputs_bi results_sha1_bi
-    ; "sha224",              makes ~name:"sha224"  bytes     `SHA224  keys_by inputs_by results_sha224_by
-    ; "sha224 (bigstring)",  makes ~name:"sha224"  bigstring `SHA224  keys_bi inputs_bi results_sha224_bi
-    ; "sha256",              makes ~name:"sha256"  bytes     `SHA256  keys_by inputs_by results_sha256_by
-    ; "sha256 (bigstring)",  makes ~name:"sha256"  bigstring `SHA256  keys_bi inputs_bi results_sha256_bi
-    ; "sha384",              makes ~name:"sha384"  bytes     `SHA384  keys_by inputs_by results_sha384_by
-    ; "sha384 (bigstring)",  makes ~name:"sha384"  bigstring `SHA384  keys_bi inputs_bi results_sha384_bi
-    ; "sha512",              makes ~name:"sha512"  bytes     `SHA512  keys_by inputs_by results_sha512_by
-    ; "sha512 (bigstring)",  makes ~name:"sha512"  bigstring `SHA512  keys_bi inputs_bi results_sha512_bi
-    ; "blake2b",             makes ~name:"blake2b" bytes     `BLAKE2B keys_by inputs_by results_blake2b_by
-    ; "blake2b (bigstring)", makes ~name:"blake2b" bigstring `BLAKE2B keys_bi inputs_bi results_blake2b_bi
-    ; "rmd160",              makes ~name:"rmd160"  bytes     `RMD160  keys_by inputs_by results_rmd160_by
-    ; "rmd160 (bigstring)",  makes ~name:"rmd160"  bigstring `RMD160  keys_bi inputs_bi results_rmd160_bi
-    ; "blake2s",             makes ~name:"blake2s" bytes     `BLAKE2S keys_by inputs_by results_blake2s_by
-    ; "blake2s (bigstring)", makes ~name:"blake2s" bigstring `BLAKE2S keys_bi inputs_bi results_blake2s_bi
+    [ "md5",                 makes ~name:"md5"     bytes     Digestif.md5     keys_by inputs_by results_md5_by
+    ; "md5 (bigstring)",     makes ~name:"md5"     bigstring Digestif.md5     keys_bi inputs_bi results_md5_bi
+    ; "sha1",                makes ~name:"sha1"    bytes     Digestif.sha1    keys_by inputs_by results_sha1_by
+    ; "sha1 (bigstring)",    makes ~name:"sha1"    bigstring Digestif.sha1    keys_bi inputs_bi results_sha1_bi
+    ; "sha224",              makes ~name:"sha224"  bytes     Digestif.sha224  keys_by inputs_by results_sha224_by
+    ; "sha224 (bigstring)",  makes ~name:"sha224"  bigstring Digestif.sha224  keys_bi inputs_bi results_sha224_bi
+    ; "sha256",              makes ~name:"sha256"  bytes     Digestif.sha256  keys_by inputs_by results_sha256_by
+    ; "sha256 (bigstring)",  makes ~name:"sha256"  bigstring Digestif.sha256  keys_bi inputs_bi results_sha256_bi
+    ; "sha384",              makes ~name:"sha384"  bytes     Digestif.sha384  keys_by inputs_by results_sha384_by
+    ; "sha384 (bigstring)",  makes ~name:"sha384"  bigstring Digestif.sha384  keys_bi inputs_bi results_sha384_bi
+    ; "sha512",              makes ~name:"sha512"  bytes     Digestif.sha512  keys_by inputs_by results_sha512_by
+    ; "sha512 (bigstring)",  makes ~name:"sha512"  bigstring Digestif.sha512  keys_bi inputs_bi results_sha512_bi
+    ; "blake2b",             makes ~name:"blake2b" bytes     Digestif.(blake2b BLAKE2B.digest_size) keys_by inputs_by results_blake2b_by
+    ; "blake2b (bigstring)", makes ~name:"blake2b" bigstring Digestif.(blake2b BLAKE2B.digest_size) keys_bi inputs_bi results_blake2b_bi
+    ; "rmd160",              makes ~name:"rmd160"  bytes     Digestif.rmd160  keys_by inputs_by results_rmd160_by
+    ; "rmd160 (bigstring)",  makes ~name:"rmd160"  bigstring Digestif.rmd160  keys_bi inputs_bi results_rmd160_bi
+    ; "blake2s",             makes ~name:"blake2s" bytes     Digestif.(blake2s BLAKE2S.digest_size) keys_by inputs_by results_blake2s_by
+    ; "blake2s (bigstring)", makes ~name:"blake2s" bigstring Digestif.(blake2s BLAKE2S.digest_size) keys_bi inputs_bi results_blake2s_bi
     ; "blake2s (input file)", BLAKE2.tests_blake2s
     ; "blake2b (input file)", BLAKE2.tests_blake2b
     ; "ripemd160", RMD160.tests ]


### PR DESCRIPTION
Ok fixed (I wrote B instead S one time ...). Before to merge, I would like to know if this PR is convenient to @hannesm and @samoht. About `ocaml-git`, this PR did not change the `S` signature, so `ocaml-git` stills to compile with this new version.

However (and may be I'm wrong), constructors (like `MD5` .. `BLAKE2S`) are _not exposed_ (and can not be exposed with the linking trick). So, I _functionarize_ constructors like:

```ocaml
val md5: unit hash
..
val blake2s: int hash
```

I'm not sure if it's the best way, so feel free to explain an other way.