### PR TITLE
Remove compare function

### DIFF
--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -48,7 +48,6 @@ module type S = sig
   val hmacv_string: key:String.t -> String.t list -> t
   val hmacv_bigstring: key:bigstring -> bigstring list -> t
   val unsafe_compare: t compare
-  val compare: t compare
   val eq: t equal
   val neq: t equal
   val pp: t pp

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -47,7 +47,6 @@ module type S = sig
   val hmacv_string: key:String.t -> String.t list -> t
   val hmacv_bigstring: key:bigstring -> bigstring list -> t
   val unsafe_compare: t compare
-  val compare: t compare
   val eq: t equal
   val neq: t equal
   val pp: t pp

--- a/src/digestif.mli
+++ b/src/digestif.mli
@@ -111,18 +111,9 @@ module type S = sig
 
   val unsafe_compare: t compare
   (** [unsafe_compare] function returns [0] on equality and a negative/positive
-     [int] depending on the difference (like {!String.compare}). However, this
-     behavior is dangerous since sorting by these hashes can allow attackers to
-     infer information about them. *)
-
-  val compare: t compare
-  (** [compare a b] uses [caml_hash] (murmur3) to get an unique integer of [a]
-     and [b] a do a substraction on them. Order is not lexicographical. The
-     safety relies on the assumption that the murmur3 seed cannot be
-     reconstructed by an attacker.
-
-     About safety, [t] is private string and let the user to define its own
-     [compare] function. *)
+      [int] depending on the difference (like {!String.compare}).
+      This is usually OK, but this is not constant time, so in some cases it
+      could leak some information. *)
 
   val eq: t equal
   (** The equal function for {!t}. *)

--- a/src/digestif_eq.ml
+++ b/src/digestif_eq.ml
@@ -13,6 +13,4 @@ module Make (D : sig val digest_size : int end) = struct
   let neq a b = not (eq a b)
 
   let unsafe_compare a b = String.compare a b
-  external int_compare : int -> int -> int = "caml_int_compare"
-  let compare a b = int_compare (Hashtbl.hash a) (Hashtbl.hash b)
 end


### PR DESCRIPTION
As discussed in #52, the comparison function based on `caml_hash` has easy collisions, so it is not suitable.
A constant-time total order is not a common requirement, so this can be left out of the public interface.

It is still possible to use constant-time equality and access the underlying string if need be.

Thanks!