### PR TITLE
Some nice to have functions in Digestif

### DIFF
--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -53,9 +53,12 @@ module type S = sig
   val neq: t equal
   val pp: t pp
   val of_hex: string -> t
+  val of_hex_opt: string -> t option
   val consistent_of_hex: string -> t
+  val consistent_of_hex_opt: string -> t option
   val to_hex: t -> string
   val of_raw_string: string -> t
+  val of_raw_string_opt: string -> t option
   val to_raw_string: t -> string
 end
 
@@ -594,11 +597,27 @@ let consistent_of_hex
     let module H = (val (module_of hash)) in
     H.to_raw_string (H.consistent_of_hex hex)
 
+let consistent_of_hex_opt
+  : type k. k hash -> string -> k t option
+  = fun hash hex ->
+    let module H = (val (module_of hash)) in
+    match H.consistent_of_hex_opt hex with
+    | None -> None
+    | Some digest -> Some (H.to_raw_string digest)
+
 let of_hex
   : type k. k hash -> string -> k t
   = fun hash hex ->
     let module H = (val (module_of hash)) in
     H.to_raw_string (H.of_hex hex)
+
+let of_hex_opt
+  : type k. k hash -> string -> k t option
+  = fun hash hex ->
+    let module H = (val (module_of hash)) in
+    match H.of_hex_opt hex with
+    | None -> None
+    | Some digest -> Some (H.to_raw_string digest)
 
 let to_hex
   : type k. k hash -> k t -> string
@@ -613,6 +632,15 @@ let of_raw_string
     let module H = (val (module_of hash)) in
     let unsafe : H.t -> 'k t = H.to_raw_string in
     unsafe (H.of_raw_string s)
+
+let of_raw_string_opt
+  : type k. k hash -> string -> k t option
+  = fun hash s ->
+    let module H = (val (module_of hash)) in
+    let unsafe : H.t -> 'k t = H.to_raw_string in
+    match H.of_raw_string_opt s with
+    | None -> None
+    | Some digest -> Some (unsafe digest)
 
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
 

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -607,7 +607,13 @@ let to_hex
     let unsafe : 'k t -> H.t = H.of_raw_string in
     H.to_hex (unsafe t)
 
-let of_raw_string: type k. k hash -> string -> k t = fun _ s -> s
+let of_raw_string
+  : type k. k hash -> string -> k t
+  = fun hash s ->
+    let module H = (val (module_of hash)) in
+    let unsafe : H.t -> 'k t = H.to_raw_string in
+    unsafe (H.of_raw_string s)
+
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
 
 let of_digest (type hash) (type kind) (module H : S with type t = hash and type kind = kind) (hash: H.t) : kind t =

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -610,6 +610,9 @@ let to_hex
 let of_raw_string: type k. k hash -> string -> k t = fun _ s -> s
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
 
+let of_digest (type hash) (type kind) (module H : S with type t = hash and type kind = kind) (hash: H.t) : kind t =
+  H.to_raw_string hash
+
 let of_md5 hash = of_raw_string md5 (MD5.to_raw_string hash)
 let of_sha1 hash = of_raw_string sha1 (SHA1.to_raw_string hash)
 let of_rmd160 hash = of_raw_string rmd160 (RMD160.to_raw_string hash)

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -504,6 +504,24 @@ let module_of : type k. k hash -> (module S with type kind = k) = fun hash ->
 
 type 'kind t = string
 
+let digest_bytes
+  : type k. k hash -> Bytes.t -> k t
+  = fun hash buf ->
+    let module H = (val (module_of hash)) in
+    (H.to_raw_string (H.digest_bytes buf) : H.kind t)
+
+let digest_string
+  : type k. k hash -> String.t -> k t
+  = fun hash buf ->
+    let module H = (val (module_of hash)) in
+    (H.to_raw_string (H.digest_string buf) : H.kind t)
+
+let digest_bigstring
+  : type k. k hash -> bigstring -> k t
+  = fun hash buf ->
+    let module H = (val (module_of hash)) in
+    (H.to_raw_string (H.digest_bigstring buf) : H.kind t)
+
 let digesti_bytes
   : type k. k hash -> Bytes.t iter -> k t
   = fun hash iter ->

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -570,6 +570,12 @@ let pp
     let unsafe : 'k t -> H.t = H.of_raw_string in
     H.pp ppf (unsafe t)
 
+let consistent_of_hex
+  : type k. k hash -> string -> k t
+  = fun hash hex ->
+    let module H = (val (module_of hash)) in
+    H.to_raw_string (H.consistent_of_hex hex)
+
 let of_hex
   : type k. k hash -> string -> k t
   = fun hash hex ->
@@ -585,3 +591,15 @@ let to_hex
 
 let of_raw_string: type k. k hash -> string -> k t = fun _ s -> s
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
+
+let of_md5 hash = of_raw_string md5 (MD5.to_raw_string hash)
+let of_sha1 hash = of_raw_string sha1 (SHA1.to_raw_string hash)
+let of_rmd160 hash = of_raw_string rmd160 (RMD160.to_raw_string hash)
+let of_sha224 hash = of_raw_string sha224 (SHA224.to_raw_string hash)
+let of_sha256 hash = of_raw_string sha256 (SHA256.to_raw_string hash)
+let of_sha384 hash = of_raw_string sha384 (SHA384.to_raw_string hash)
+let of_sha512 hash = of_raw_string sha512 (SHA512.to_raw_string hash)
+let of_blake2b hash =
+  of_raw_string (blake2b BLAKE2B.digest_size) (BLAKE2B.to_raw_string hash)
+let of_blake2s hash =
+  of_raw_string (blake2s BLAKE2S.digest_size) (BLAKE2S.to_raw_string hash)

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -465,6 +465,24 @@ let module_of : type k. k hash -> (module S with type kind = k) = fun hash ->
 
 type 'kind t = string
 
+let digest_bytes
+  : type k. k hash -> Bytes.t -> k t
+  = fun hash buf ->
+    let module H = (val (module_of hash)) in
+    (H.to_raw_string (H.digest_bytes buf) : H.kind t)
+
+let digest_string
+  : type k. k hash -> String.t -> k t
+  = fun hash buf ->
+    let module H = (val (module_of hash)) in
+    (H.to_raw_string (H.digest_string buf) : H.kind t)
+
+let digest_bigstring
+  : type k. k hash -> bigstring -> k t
+  = fun hash buf ->
+    let module H = (val (module_of hash)) in
+    (H.to_raw_string (H.digest_bigstring buf) : H.kind t)
+
 let digesti_bytes
   : type k. k hash -> Bytes.t iter -> k t
   = fun hash iter ->

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -568,7 +568,13 @@ let to_hex
     let unsafe : 'k t -> H.t = H.of_raw_string in
     H.to_hex (unsafe t)
 
-let of_raw_string: type k. k hash -> string -> k t = fun _ t -> t
+let of_raw_string
+  : type k. k hash -> string -> k t
+  = fun hash s ->
+    let module H = (val (module_of hash)) in
+    let unsafe : H.t -> 'k t = H.to_raw_string in
+    unsafe (H.of_raw_string s)
+
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
 
 let of_digest (type hash) (type kind) (module H : S with type t = hash and type kind = kind) (hash: H.t) : kind t =

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -571,6 +571,9 @@ let to_hex
 let of_raw_string: type k. k hash -> string -> k t = fun _ t -> t
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
 
+let of_digest (type hash) (type kind) (module H : S with type t = hash and type kind = kind) (hash: H.t) : kind t =
+  H.to_raw_string hash
+
 let of_md5 hash = of_raw_string md5 (MD5.to_raw_string hash)
 let of_sha1 hash = of_raw_string sha1 (SHA1.to_raw_string hash)
 let of_rmd160 hash = of_raw_string rmd160 (RMD160.to_raw_string hash)

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -52,9 +52,12 @@ module type S = sig
   val neq: t equal
   val pp: t pp
   val of_hex: string -> t
+  val of_hex_opt: string -> t option
   val consistent_of_hex: string -> t
+  val consistent_of_hex_opt: string -> t option
   val to_hex: t -> string
   val of_raw_string: string -> t
+  val of_raw_string_opt: string -> t option
   val to_raw_string: t -> string
 end
 
@@ -555,11 +558,27 @@ let of_hex
     let module H = (val (module_of hash)) in
     H.to_raw_string (H.of_hex hex)
 
+let of_hex_opt
+  : type k. k hash -> string -> k t option
+  = fun hash hex ->
+    let module H = (val (module_of hash)) in
+    match H.of_hex_opt hex with
+    | None -> None
+    | Some digest -> Some (H.to_raw_string digest)
+
 let consistent_of_hex
   : type k. k hash -> string -> k t
   = fun hash hex ->
     let module H = (val (module_of hash)) in
     H.to_raw_string (H.consistent_of_hex hex)
+
+let consistent_of_hex_opt
+  : type k. k hash -> string -> k t option
+  = fun hash hex ->
+    let module H = (val (module_of hash)) in
+    match H.consistent_of_hex_opt hex with
+    | None -> None
+    | Some digest -> Some (H.to_raw_string digest)
 
 let to_hex
   : type k. k hash -> k t -> string
@@ -574,6 +593,15 @@ let of_raw_string
     let module H = (val (module_of hash)) in
     let unsafe : H.t -> 'k t = H.to_raw_string in
     unsafe (H.of_raw_string s)
+
+let of_raw_string_opt
+  : type k. k hash -> string -> k t option
+  = fun hash s ->
+    let module H = (val (module_of hash)) in
+    let unsafe : H.t -> 'k t = H.to_raw_string in
+    match H.of_raw_string_opt s with
+    | None -> None
+    | Some digest -> Some (unsafe digest)
 
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
 

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -537,6 +537,12 @@ let of_hex
     let module H = (val (module_of hash)) in
     H.to_raw_string (H.of_hex hex)
 
+let consistent_of_hex
+  : type k. k hash -> string -> k t
+  = fun hash hex ->
+    let module H = (val (module_of hash)) in
+    H.to_raw_string (H.consistent_of_hex hex)
+
 let to_hex
   : type k. k hash -> k t -> string
   = fun hash t ->
@@ -546,3 +552,15 @@ let to_hex
 
 let of_raw_string: type k. k hash -> string -> k t = fun _ t -> t
 let to_raw_string: type k. k hash -> k t -> string = fun _ t -> t
+
+let of_md5 hash = of_raw_string md5 (MD5.to_raw_string hash)
+let of_sha1 hash = of_raw_string sha1 (SHA1.to_raw_string hash)
+let of_rmd160 hash = of_raw_string rmd160 (RMD160.to_raw_string hash)
+let of_sha224 hash = of_raw_string sha224 (SHA224.to_raw_string hash)
+let of_sha256 hash = of_raw_string sha256 (SHA256.to_raw_string hash)
+let of_sha384 hash = of_raw_string sha384 (SHA384.to_raw_string hash)
+let of_sha512 hash = of_raw_string sha512 (SHA512.to_raw_string hash)
+let of_blake2b hash =
+  of_raw_string (blake2b BLAKE2B.digest_size) (BLAKE2B.to_raw_string hash)
+let of_blake2s hash =
+  of_raw_string (blake2s BLAKE2S.digest_size) (BLAKE2S.to_raw_string hash)

--- a/src/digestif.mli
+++ b/src/digestif.mli
@@ -246,6 +246,17 @@ val unsafe_compare: 'k hash -> 'k t compare
 
 val to_hex: 'k hash -> 'k t -> string
 val of_hex: 'k hash -> string -> 'k t
+val consistent_of_hex: 'k hash -> string -> 'k t
 
 val of_raw_string: 'k hash -> string -> 'k t
 val to_raw_string: 'k hash -> 'k t -> string
+
+val of_md5: MD5.t -> [ `MD5 ] t
+val of_sha1: SHA1.t -> [ `SHA1 ] t
+val of_rmd160: RMD160.t -> [ `RMD160 ] t
+val of_sha224: SHA224.t -> [ `SHA224 ] t
+val of_sha256: SHA256.t -> [ `SHA256 ] t
+val of_sha384: SHA384.t -> [ `SHA384 ] t
+val of_sha512: SHA512.t -> [ `SHA512 ] t
+val of_blake2b: BLAKE2B.t -> [ `BLAKE2B ] t
+val of_blake2s: BLAKE2S.t -> [ `BLAKE2S ] t

--- a/src/digestif.mli
+++ b/src/digestif.mli
@@ -255,6 +255,9 @@ val consistent_of_hex: 'k hash -> string -> 'k t
 val of_raw_string: 'k hash -> string -> 'k t
 val to_raw_string: 'k hash -> 'k t -> string
 
+val of_digest:
+  (module S with type t = 'hash and type kind = 'k) -> 'hash -> 'k t
+
 val of_md5: MD5.t -> [ `MD5 ] t
 val of_sha1: SHA1.t -> [ `SHA1 ] t
 val of_rmd160: RMD160.t -> [ `RMD160 ] t

--- a/src/digestif.mli
+++ b/src/digestif.mli
@@ -231,6 +231,10 @@ type 'kind t
 
 val module_of: 'k hash -> (module S with type kind = 'k)
 
+val digest_bytes: 'k hash -> Bytes.t -> 'k t
+val digest_string: 'k hash -> String.t -> 'k t
+val digest_bigstring: 'k hash -> bigstring -> 'k t
+
 val digesti_bytes: 'k hash -> Bytes.t iter -> 'k t
 val digesti_string: 'k hash -> String.t iter -> 'k t
 val digesti_bigstring: 'k hash -> bigstring iter -> 'k t

--- a/src/digestif.mli
+++ b/src/digestif.mli
@@ -134,6 +134,13 @@ module type S = sig
      enough hexadecimal values, trailing values of the output hash are zero
      ([\x00]), *)
 
+  val of_hex_opt: string -> t option
+  (** [of_hex] tries to parse an hexadecimal representation of {!t}. [of_hex]
+      returns [None] when input is malformed. We take only first {!digest_size}
+      hexadecimal values and ignore rest of input. If it has not enough
+      hexadecimal values, trailing values of the output hash are zero
+      ([\x00]). *)
+
   val consistent_of_hex: string -> t
   (** [consistent_of_hex] tries to parse an hexadecimal representation of {!t}.
      [consistent_of_hex] raises an [invalid_argument] when input is malformed.
@@ -141,12 +148,24 @@ module type S = sig
      [{!digest_size} * 2] hexadecimal values (but continues to ignore
      whitespaces). *)
 
+  val consistent_of_hex_opt: string -> t option
+  (** [consistent_of_hex_opt] tries to parse an hexadecimal representation of
+      {!t}. [consistent_of_hex] returns [None] when input is malformed.
+      However, instead {!of_hex}, [consistent_of_hex] expects exactly
+      [{!digest_size} * 2] hexadecimal values (but continues to ignore
+      whitespaces). *)
+
   val to_hex: t -> string
   (** [to_hex] makes a hex-decimal representation of {!t}. *)
 
   val of_raw_string: string -> t
   (** [of_raw_string s] see [s] as a hash. Useful when reading
      serialized hashes. *)
+
+  val of_raw_string_opt: string -> t option
+  (** [of_raw_string_opt s] see [s] as a hash. Useful when reading
+      serialized hashes.  Returns [None] if [s] is not the {!digest_size}
+      bytes long. *)
 
   val to_raw_string: t -> string
   (** [to_raw_string s] is [(s :> string)]. *)
@@ -250,9 +269,12 @@ val unsafe_compare: 'k hash -> 'k t compare
 
 val to_hex: 'k hash -> 'k t -> string
 val of_hex: 'k hash -> string -> 'k t
+val of_hex_opt: 'k hash -> string -> 'k t option
 val consistent_of_hex: 'k hash -> string -> 'k t
+val consistent_of_hex_opt: 'k hash -> string -> 'k t option
 
 val of_raw_string: 'k hash -> string -> 'k t
+val of_raw_string_opt: 'k hash -> string -> 'k t option
 val to_raw_string: 'k hash -> 'k t -> string
 
 val of_digest:

--- a/src/digestif_conv.ml
+++ b/src/digestif_conv.ml
@@ -44,6 +44,11 @@ module Make (D : sig val digest_size : int end) = struct
           else invalid_arg "of_hex: odd number of hex characters" in
     String.init D.digest_size (go false)
 
+  let of_hex_opt hex =
+    match of_hex hex with
+    | digest -> Some digest
+    | exception _ -> None
+
   let consistent_of_hex str =
     let offset = ref 0 in
     let rec go have_first idx =
@@ -68,6 +73,11 @@ module Make (D : sig val digest_size : int end) = struct
     if !offset + D.digest_size = String.length str
     then res else invalid_arg "Too much enough bytes (reach: %d, expect: %d)" (!offset + (D.digest_size * 2)) (String.length str)
 
+  let consistent_of_hex_opt hex =
+    match consistent_of_hex hex with
+    | digest -> Some digest
+    | exception _ -> None
+
   let pp ppf hash =
     for i = 0 to D.digest_size - 1
     do Format.fprintf ppf "%02x" (Char.code (String.get hash i)) done
@@ -75,6 +85,11 @@ module Make (D : sig val digest_size : int end) = struct
   let of_raw_string x =
     if String.length x <> D.digest_size then invalid_arg "invalid hash size"
     else x
+
+  let of_raw_string_opt x =
+    match of_raw_string x with
+    | digest -> Some digest
+    | exception _ -> None
 
   let to_raw_string x = x
 


### PR DESCRIPTION
I've been porting some pre-0.6 code to the digestif `master` branch and found these functions to be useful in the process.

The only change to existing functionality should be in b5e833c which adds a check to `Digestif.of_raw_string` which should probably be there for consistency with `Digestif.*.of_raw_string`.