### PR TITLE
Release rumtime lock in XXX_ba_update functions to allow parallel execution

### DIFF
--- a/src-c/digestif_native.ml
+++ b/src-c/digestif_native.ml
@@ -32,7 +32,6 @@ module MD5 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_md5_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -66,7 +65,6 @@ module SHA1 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_sha1_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -100,7 +98,6 @@ module SHA224 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_sha224_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -134,7 +131,6 @@ module SHA256 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_sha256_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -168,7 +164,6 @@ module SHA384 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_sha384_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -202,7 +197,6 @@ module SHA512 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_sha512_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -236,7 +230,6 @@ module BLAKE2B = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_blake2b_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -287,7 +280,6 @@ module BLAKE2S = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_blake2s_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit
@@ -338,7 +330,6 @@ module RMD160 = struct
     external update :
       ctx -> ba -> off -> size -> unit
       = "caml_digestif_rmd160_ba_update"
-      [@@noalloc]
 
     external finalize :
       ctx -> ba -> off -> unit

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -28,14 +28,14 @@
   CAMLprim value                                                             \
   caml_digestif_ ## name ## _ba_update (value ctx, value src, value off, value len) { \
     CAMLparam4 (ctx, src, off, len);                                         \
-    uint8_t *off_ = Caml_ba_data_val(src) + Int_val (off);                   \
-    int len_ = Int_val (len);                                                \
+    uint8_t *off_ = ((uint8_t*) Caml_ba_data_val(src)) + Long_val (off);     \
+    uint32_t len_ = Long_val (len);                                          \
     struct name ## _ctx ctx_;                                                \
-    memcpy(&ctx_, String_val(ctx), sizeof(struct name ## _ctx));             \
+    memcpy(&ctx_, Bytes_val(ctx), sizeof(struct name ## _ctx));              \
     caml_release_runtime_system();                                           \
     digestif_ ## name ## _update (&ctx_, off_, len_);                        \
     caml_acquire_runtime_system();                                           \
-    memcpy(String_val(ctx), &ctx_, sizeof(struct name ## _ctx));             \
+    memcpy(Bytes_val(ctx), &ctx_, sizeof(struct name ## _ctx));              \
     CAMLreturn (Val_unit);                                                   \
   }                                                                          \
                                                                              \

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -11,6 +11,12 @@
 #include <caml/memory.h>
 #include <string.h>
 
+#ifdef CAML_SAFE_STRING
+#define Ctx_val(x) Bytes_val(x)
+#else
+#define Ctx_val(x) String_val(x)
+#endif
+
 #define __define_hash(name, upper)                                           \
                                                                              \
   CAMLprim value                                                             \
@@ -31,11 +37,11 @@
     uint8_t *off_ = ((uint8_t*) Caml_ba_data_val(src)) + Long_val (off);     \
     uint32_t len_ = Long_val (len);                                          \
     struct name ## _ctx ctx_;                                                \
-    memcpy(&ctx_, Bytes_val(ctx), sizeof(struct name ## _ctx));              \
+    memcpy(&ctx_, Ctx_val(ctx), sizeof(struct name ## _ctx));                \
     caml_release_runtime_system();                                           \
     digestif_ ## name ## _update (&ctx_, off_, len_);                        \
     caml_acquire_runtime_system();                                           \
-    memcpy(Bytes_val(ctx), &ctx_, sizeof(struct name ## _ctx));              \
+    memcpy(Ctx_val(ctx), &ctx_, sizeof(struct name ## _ctx));                \
     CAMLreturn (Val_unit);                                                   \
   }                                                                          \
                                                                              \

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -11,10 +11,8 @@
 #include <caml/memory.h>
 #include <string.h>
 
-#ifdef CAML_SAFE_STRING
-#define Ctx_val(x) Bytes_val(x)
-#else
-#define Ctx_val(x) String_val(x)
+#ifndef Bytes_val
+#define Bytes_val(x) String_val(x)
 #endif
 
 #define __define_hash(name, upper)                                           \
@@ -37,11 +35,11 @@
     uint8_t *off_ = ((uint8_t*) Caml_ba_data_val(src)) + Long_val (off);     \
     uint32_t len_ = Long_val (len);                                          \
     struct name ## _ctx ctx_;                                                \
-    memcpy(&ctx_, Ctx_val(ctx), sizeof(struct name ## _ctx));                \
+    memcpy(&ctx_, Bytes_val(ctx), sizeof(struct name ## _ctx));                \
     caml_release_runtime_system();                                           \
     digestif_ ## name ## _update (&ctx_, off_, len_);                        \
     caml_acquire_runtime_system();                                           \
-    memcpy(Ctx_val(ctx), &ctx_, sizeof(struct name ## _ctx));                \
+    memcpy(Bytes_val(ctx), &ctx_, sizeof(struct name ## _ctx));                \
     CAMLreturn (Val_unit);                                                   \
   }                                                                          \
                                                                              \


### PR DESCRIPTION
The changes adds an overhead of around 70ns(8ns vs 79ns) on an Intel 7-7500U CPU @ 2.70GHz.
the overhead is primarily introduced by the release and acquisition of the runtime lock (50ms). 20 ms is used for copying ctx onto the stack and back. This could be reduced by letting the c-stub create a new ctx itself, and remove the need of calling `dup`, which saves around 20ns per call. 

See #69. 



