### PR TITLE
conflict with mirage-xen-posix versions that don't install a META file

### DIFF
--- a/digestif.opam
+++ b/digestif.opam
@@ -49,5 +49,6 @@ depopts: [
 ]
 
 conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
   "ocaml-freestanding" {< "0.4.1"}
 ]


### PR DESCRIPTION
currently released to opam-repository https://github.com/ocaml/opam-repository/pull/12999