### PR TITLE
Fix bug about specialization of BLAKE2{S,B}

### DIFF
--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -148,7 +148,6 @@ module Unsafe (F : Foreign) (D : Desc) = struct
   let unsafe_get t =
     let res = By.create digest_size in
     By.fill res 0 digest_size '\000' ;
-    Format.eprintf "(OCaml) Finalize\n%!" ;
     F.Bytes.finalize t res 0 ; res
 end
 

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -13,6 +13,8 @@ module Eq = Digestif_eq
 module Hash = Digestif_hash
 module Conv = Digestif_conv
 
+let failwith fmt = Format.ksprintf failwith fmt
+
 module type S = sig
   val digest_size : int
 
@@ -313,11 +315,16 @@ module type Foreign_BLAKE2 = sig
     val with_outlen_and_key : ctx -> int -> st -> int -> int -> unit
   end
 
+  val max_outlen : unit -> int
   val ctx_size : unit -> int
   val key_size : unit -> int
 end
 
 module Make_BLAKE2 (F : Foreign_BLAKE2) (D : Desc) = struct
+  let () =
+    if D.digest_size > F.max_outlen ()
+    then failwith "Invalid digest_size:%d to make a BLAKE2{S,B} implementation" D.digest_size
+
   include Make (struct
       type kind = F.kind
 

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -114,8 +114,9 @@ module Unsafe (F : Foreign) (D : Desc) = struct
     let t = By.create ctx_size in
     F.Bytes.init t ; t
 
-  let empty = Bytes.create ctx_size
-  let () = ignore @@ F.Bytes.init empty
+  let empty =
+    let buf = Bytes.create ctx_size in
+    F.Bytes.init buf ; buf
 
   let unsafe_feed_bytes t ?off ?len buf =
     let off, len =

--- a/src-c/digestif_native.ml
+++ b/src-c/digestif_native.ml
@@ -300,6 +300,9 @@ module BLAKE2B = struct
   external key_size : unit -> int = "caml_digestif_blake2b_key_size"
     [@@noalloc]
 
+  external max_outlen : unit -> int = "caml_digestif_blake2b_max_outlen"
+    [@@noalloc]
+
   external digest_size : ctx -> int = "caml_digestif_blake2b_digest_size"
     [@@noalloc]
 end
@@ -348,6 +351,9 @@ module BLAKE2S = struct
     [@@noalloc]
 
   external key_size : unit -> int = "caml_digestif_blake2s_key_size"
+    [@@noalloc]
+
+  external max_outlen : unit -> int = "caml_digestif_blake2s_max_outlen"
     [@@noalloc]
 
   external digest_size : ctx -> int = "caml_digestif_blake2s_digest_size"

--- a/src-c/native/blake2b.c
+++ b/src-c/native/blake2b.c
@@ -215,12 +215,6 @@ void digestif_blake2b_finalize( struct blake2b_ctx *ctx, uint8_t *out )
     store64(buffer + sizeof( ctx->h[i] ) * i, ctx->h[i]);
 
   secure_zero_memory( out, ctx->outlen * sizeof(uint8_t) );
-
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
-  memcpy( out, buffer, MIN(ctx->outlen, BLAKE2B_OUTBYTES) );
-
-#undef MIN
-
+  memcpy( out, buffer, (ctx->outlen < BLAKE2B_OUTBYTES) ? ctx->outlen : BLAKE2B_OUTBYTES );
   secure_zero_memory( buffer, sizeof(buffer) );
 }

--- a/src-c/native/blake2b.c
+++ b/src-c/native/blake2b.c
@@ -214,6 +214,13 @@ void digestif_blake2b_finalize( struct blake2b_ctx *ctx, uint8_t *out )
   for( i = 0; i < 8; ++i )
     store64(buffer + sizeof( ctx->h[i] ) * i, ctx->h[i]);
 
-  memcpy( out, buffer, ctx->outlen );
+  secure_zero_memory( out, ctx->outlen * sizeof(uint8_t) );
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+  memcpy( out, buffer, MIN(ctx->outlen, BLAKE2B_OUTBYTES) );
+
+#undef MIN
+
   secure_zero_memory( buffer, sizeof(buffer) );
 }

--- a/src-c/native/blake2s.c
+++ b/src-c/native/blake2s.c
@@ -207,13 +207,7 @@ void digestif_blake2s_finalize( struct blake2s_ctx *ctx, uint8_t *out )
     store32(buffer + sizeof( ctx->h[i] ) * i, ctx->h[i]);
 
   secure_zero_memory( out, ctx->outlen * sizeof(uint8_t) );
-
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
-  memcpy( out, buffer, MIN(ctx->outlen, BLAKE2S_OUTBYTES) );
-
-#undef MIN
-
+  memcpy( out, buffer, (ctx->outlen < BLAKE2S_OUTBYTES) ? ctx->outlen : BLAKE2S_OUTBYTES );
   secure_zero_memory( buffer, sizeof(buffer) );
 }
 

--- a/src-c/native/blake2s.c
+++ b/src-c/native/blake2s.c
@@ -206,7 +206,14 @@ void digestif_blake2s_finalize( struct blake2s_ctx *ctx, uint8_t *out )
   for( i = 0; i < 8; ++i )
     store32(buffer + sizeof( ctx->h[i] ) * i, ctx->h[i]);
 
-  memcpy( out, buffer, ctx->outlen );
+  secure_zero_memory( out, ctx->outlen * sizeof(uint8_t) );
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+  memcpy( out, buffer, MIN(ctx->outlen, BLAKE2S_OUTBYTES) );
+
+#undef MIN
+
   secure_zero_memory( buffer, sizeof(buffer) );
 }
 

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -112,6 +112,11 @@ caml_digestif_blake2b_key_size(__unit ()) {
 }
 
 CAMLprim value
+caml_digestif_blake2b_max_outlen(__unit ()) {
+  return Val_int (BLAKE2B_OUTBYTES);
+}
+
+CAMLprim value
 caml_digestif_blake2b_digest_size(value ctx) {
   return Val_int(((struct blake2b_ctx *) String_val (ctx))->outlen);
 }
@@ -139,6 +144,11 @@ caml_digestif_blake2s_st_init_with_outlen_and_key(value ctx, value outlen, value
 CAMLprim value
 caml_digestif_blake2s_key_size(__unit ()) {
   return Val_int (BLAKE2S_KEYBYTES);
+}
+
+CAMLprim value
+caml_digestif_blake2s_max_outlen(__unit ()) {
+  return Val_int (BLAKE2S_OUTBYTES);
 }
 
 CAMLprim value

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -12,8 +12,6 @@
 #include <caml/memory.h>
 #include <string.h>
 
-#include <stdio.h>
-
 #ifndef Bytes_val
 #define Bytes_val(x) String_val(x)
 #endif

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -12,6 +12,8 @@
 #include <caml/memory.h>
 #include <string.h>
 
+#include <stdio.h>
+
 #ifndef Bytes_val
 #define Bytes_val(x) String_val(x)
 #endif

--- a/src-ocaml/baijiu_blake2b.ml
+++ b/src-ocaml/baijiu_blake2b.ml
@@ -343,5 +343,10 @@ module Unsafe : S = struct
     for i = 0 to 7 do
       By.cpu_to_le64 res (i * 8) ctx.h.(i)
     done ;
-    By.sub res 0 ctx.outlen
+    if ctx.outlen < default_param.digest_length
+    then By.sub res 0 ctx.outlen
+    else if ctx.outlen > default_param.digest_length
+    then ( let res' = By.make ctx.outlen '\x00' in
+           By.blit res 0 res' 0 64 ; res' )
+    else res 
 end

--- a/src-ocaml/baijiu_blake2b.ml
+++ b/src-ocaml/baijiu_blake2b.ml
@@ -41,6 +41,7 @@ module type S = sig
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
   val unsafe_get : ctx -> By.t
   val dup : ctx -> ctx
+  val max_outlen : int
 end
 
 module Unsafe : S = struct
@@ -148,8 +149,10 @@ module Unsafe : S = struct
     in
     By.init 64 (fun i -> Char.unsafe_chr arr.(i))
 
+  let max_outlen = 64
+
   let default_param =
-    { digest_length= 64
+    { digest_length= max_outlen
     ; key_length= 0
     ; fanout= 1
     ; depth= 1
@@ -345,8 +348,9 @@ module Unsafe : S = struct
     done ;
     if ctx.outlen < default_param.digest_length
     then By.sub res 0 ctx.outlen
+    (* XXX(dinosaure): should never appear! *)
     else if ctx.outlen > default_param.digest_length
     then ( let res' = By.make ctx.outlen '\x00' in
            By.blit res 0 res' 0 64 ; res' )
-    else res 
+    else res
 end

--- a/src-ocaml/baijiu_blake2b.ml
+++ b/src-ocaml/baijiu_blake2b.ml
@@ -338,7 +338,7 @@ module Unsafe : S = struct
     with_outlen_and_key ~blit:By.blit_from_bigstring outlen key off len
 
   let unsafe_get ctx =
-    let res = By.make 64 '\x00' in
+    let res = By.make default_param.digest_length '\x00' in
     increment_counter ctx (Int64.of_int ctx.buflen) ;
     set_lastblock ctx ;
     By.fill ctx.buf ctx.buflen (128 - ctx.buflen) '\x00' ;
@@ -351,6 +351,6 @@ module Unsafe : S = struct
     (* XXX(dinosaure): should never appear! *)
     else if ctx.outlen > default_param.digest_length
     then ( let res' = By.make ctx.outlen '\x00' in
-           By.blit res 0 res' 0 64 ; res' )
+           By.blit res 0 res' 0 default_param.digest_length ; res' )
     else res
 end

--- a/src-ocaml/baijiu_blake2s.ml
+++ b/src-ocaml/baijiu_blake2s.ml
@@ -303,5 +303,10 @@ module Unsafe : S = struct
     for i = 0 to 7 do
       By.cpu_to_le32 res (i * 4) ctx.h.(i)
     done ;
-    By.sub res 0 ctx.outlen
+    if ctx.outlen < default_param.digest_length
+    then By.sub res 0 ctx.outlen
+    else if ctx.outlen > default_param.digest_length
+    then ( let res' = By.make ctx.outlen '\x00' in
+           By.blit res 0 res' 0 32 ; res' )
+    else res
 end

--- a/src-ocaml/baijiu_blake2s.ml
+++ b/src-ocaml/baijiu_blake2s.ml
@@ -41,6 +41,7 @@ module type S = sig
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
   val unsafe_get : ctx -> By.t
   val dup : ctx -> ctx
+  val max_outlen : int
 end
 
 module Unsafe : S = struct
@@ -115,8 +116,10 @@ module Unsafe : S = struct
     in
     By.init 32 (fun i -> Char.unsafe_chr arr.(i))
 
+  let max_outlen = 32
+
   let default_param =
-    { digest_length= 32
+    { digest_length= max_outlen
     ; key_length= 0
     ; fanout= 1
     ; depth= 1
@@ -305,6 +308,7 @@ module Unsafe : S = struct
     done ;
     if ctx.outlen < default_param.digest_length
     then By.sub res 0 ctx.outlen
+    (* XXX(dinosaure): should never appear! *)
     else if ctx.outlen > default_param.digest_length
     then ( let res' = By.make ctx.outlen '\x00' in
            By.blit res 0 res' 0 32 ; res' )

--- a/src-ocaml/baijiu_blake2s.ml
+++ b/src-ocaml/baijiu_blake2s.ml
@@ -298,7 +298,7 @@ module Unsafe : S = struct
     with_outlen_and_key ~blit:By.blit_from_bigstring outlen key off len
 
   let unsafe_get ctx =
-    let res = By.make 32 '\x00' in
+    let res = By.make default_param.digest_length '\x00' in
     increment_counter ctx (Int32.of_int ctx.buflen) ;
     set_lastblock ctx ;
     By.fill ctx.buf ctx.buflen (64 - ctx.buflen) '\x00' ;
@@ -311,6 +311,6 @@ module Unsafe : S = struct
     (* XXX(dinosaure): should never appear! *)
     else if ctx.outlen > default_param.digest_length
     then ( let res' = By.make ctx.outlen '\x00' in
-           By.blit res 0 res' 0 32 ; res' )
+           By.blit res 0 res' 0 default_param.digest_length ; res' )
     else res
 end

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -280,7 +280,6 @@ module type Hash_BLAKE2 = sig
   type ctx
   type kind
 
-  val init : unit -> ctx
   val with_outlen_and_bytes_key : int -> By.t -> int -> int -> ctx
   val with_outlen_and_bigstring_key : int -> Bi.t -> int -> int -> ctx
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
@@ -290,7 +289,16 @@ module type Hash_BLAKE2 = sig
 end
 
 module Make_BLAKE2 (H : Hash_BLAKE2) (D : Desc) = struct
-  include Make (H) (D)
+  include Make (struct
+      type ctx = H.ctx
+      type kind = H.kind
+
+      let init () = H.with_outlen_and_bytes_key D.digest_size By.empty 0 0
+      let unsafe_feed_bytes = H.unsafe_feed_bytes
+      let unsafe_feed_bigstring = H.unsafe_feed_bigstring
+      let unsafe_get = H.unsafe_get
+      let dup = H.dup
+    end) (D)
 
   type outer = t
 

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -12,6 +12,8 @@ module Eq = Digestif_eq
 module Hash = Digestif_hash
 module Conv = Digestif_conv
 
+let failwith fmt = Format.ksprintf failwith fmt
+
 module type S = sig
   val digest_size : int
 
@@ -286,9 +288,14 @@ module type Hash_BLAKE2 = sig
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
   val unsafe_get : ctx -> By.t
   val dup : ctx -> ctx
+  val max_outlen : int
 end
 
 module Make_BLAKE2 (H : Hash_BLAKE2) (D : Desc) = struct
+  let () =
+    if D.digest_size > H.max_outlen
+    then failwith "Invalid digest_size:%d to make a BLAKE2{S,B} implementation" D.digest_size
+
   include Make (struct
       type ctx = H.ctx
       type kind = H.kind

--- a/test/c/dune
+++ b/test/c/dune
@@ -1,6 +1,11 @@
-(test
- (name      test)
- (deps      ../blake2b.test ../blake2s.test)
+(executable
+ (name test)
+ (modules test)
  (libraries fmt alcotest digestif.c))
+
+(alias
+ (name runtest)
+ (deps (:test test.exe) ../blake2b.test ../blake2s.test)
+ (action (run %{test} --color=always)))
 
 (rule (copy# ../test.ml test.ml))

--- a/test/ocaml/dune
+++ b/test/ocaml/dune
@@ -1,6 +1,11 @@
-(test
- (name      test)
- (deps      ../blake2b.test ../blake2s.test)
+(executable
+ (name test)
+ (modules test)
  (libraries fmt alcotest digestif.ocaml))
+
+(alias
+ (name runtest)
+ (deps (:test test.exe) ../blake2b.test ../blake2s.test)
+ (action (run %{test} --color=always)))
 
 (rule (copy# ../test.ml test.ml))

--- a/test/test.ml
+++ b/test/test.ml
@@ -489,11 +489,11 @@ let tests () =
     ; "blake2s (keyed, input file)", BLAKE2.tests_blake2s
     ; "blake2b (keyed, input file)", BLAKE2.tests_blake2b
     ; "blake2s (specialization)", [ blake2s_spe 32
-                                  ; blake2s_spe 64
-                                  ; blake2s_spe 128 ]
+                                  ; blake2s_spe 8
+                                  ; blake2s_spe 16 ]
     ; "blake2b (specialization)", [ blake2b_spe 32
                                   ; blake2b_spe 64
-                                  ; blake2b_spe 128 ]
+                                  ; blake2b_spe 16 ]
     ; "ripemd160", RMD160.tests ]
 
 let () = tests ()


### PR DESCRIPTION
This bug concerns only when you use `Make_BLAKE2{S,B}`. Default values of BLAKE2{S,B} works fine but when you specialize `outlen`, we got a segfault on `digestif.c` and a failure on `digestif.ocaml`. About expected behaviors, in this case fill result by `\x00` when length is upper than `BLAKE2{S,B}_OUTBYTES`, I'm not sure.

Important note: [reference implementation](https://github.com/BLAKE2/BLAKE2/blob/master/ref/blake2s-ref.c#L260) does not protect user against a larger `out` than `BLAKE2{S,B}_OUTBYTES`

/cc @samoht @cfcs @hannesm 