### PR TITLE
Revert variants

### DIFF
--- a/META.digestif.template
+++ b/META.digestif.template
@@ -1,0 +1,4 @@
+# DUNE_GEN
+
+xen_linkopts = "-l:rakia/xen/librakia_xen_stubs.a"
+freestanding_linkopts = "-l:rakia/freestanding/librakia_freestanding_stubs.a"

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -1,0 +1,13 @@
+open Mirage
+
+let hasheur =
+  foreign "Unikernel.Make"
+    (console @-> job)
+
+let packages =
+  [ package ~sublibs:["c"] "digestif"
+  ; package "fmt" ]
+
+let () =
+  register "hasheur"
+    ~packages [ hasheur $ default_console ]

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -1,0 +1,8 @@
+module Make (Console : Mirage_types_lwt.CONSOLE)
+= struct
+  let log console fmt = Fmt.kstrf (Console.log console) fmt
+
+  let start console =
+    let hash = Digestif.SHA1.digest_string "" in
+    log console "%a%!" Digestif.SHA1.pp hash
+end

--- a/src-c/dune
+++ b/src-c/dune
@@ -1,7 +1,7 @@
 (library
  (name        digestif_c)
  (public_name digestif.c)
- (implements  digestif)
+ (wrapped     false)
  (libraries   bigarray-compat eqaf digestif.rakia)
  (private_modules digestif_native
                   digestif_hash
@@ -11,6 +11,7 @@
                   digestif_bi)
  (flags       (:standard -no-keep-locs)))
 
+(rule (copy# ../src/digestif.mli     digestif.mli))
 (rule (copy# ../src/digestif_bi.ml   digestif_bi.ml))
 (rule (copy# ../src/digestif_by.ml   digestif_by.ml))
 (rule (copy# ../src/digestif_eq.ml   digestif_eq.ml))

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -1,7 +1,7 @@
 (library
  (name        digestif_ocaml)
  (public_name digestif.ocaml)
- (implements  digestif)
+ (wrapped     false)
  (libraries   bigarray-compat eqaf)
  (private_modules xor
                   digestif_hash
@@ -21,6 +21,7 @@
                   baijiu_blake2b)
  (flags       (:standard -no-keep-locs)))
 
+(rule (copy# ../src/digestif.mli     digestif.mli))
 (rule (copy# ../src/digestif_bi.ml   digestif_bi.ml))
 (rule (copy# ../src/digestif_by.ml   digestif_by.ml))
 (rule (copy# ../src/digestif_eq.ml   digestif_eq.ml))

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,5 @@
  (public_name digestif)
  (modules     digestif)
  (wrapped     false)
- (virtual_modules digestif)
- (default_implementation digestif.c)
+ (modules_without_implementation digestif)
  (libraries   eqaf bigarray-compat))


### PR DESCRIPTION
A minor patch to keep compatibility with `mirage.3.5.1`. It provides an end-to-end unikernel too which was tested with `unix` and `hvt` target (/cc @hannesm). However, we can not merge it, when we choose to use variants, generation of META-file is not allowed now.