### PR TITLE
Preview of ocamlformat.0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.15.0
+version = 0.16.0
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters=no

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -379,29 +379,30 @@ module Make_BLAKE2 (F : Foreign_BLAKE2) (D : Desc) = struct
       failwith "Invalid digest_size:%d to make a BLAKE2{S,B} implementation"
         D.digest_size
 
-  include Make
-            (struct
-              module Bigstring = struct
-                let init ctx =
-                  F.Bigstring.with_outlen_and_key ctx D.digest_size Bi.empty 0 0
+  include
+    Make
+      (struct
+        module Bigstring = struct
+          let init ctx =
+            F.Bigstring.with_outlen_and_key ctx D.digest_size Bi.empty 0 0
 
-                let update = F.Bigstring.update
+          let update = F.Bigstring.update
 
-                let finalize = F.Bigstring.finalize
-              end
+          let finalize = F.Bigstring.finalize
+        end
 
-              module Bytes = struct
-                let init ctx =
-                  F.Bytes.with_outlen_and_key ctx D.digest_size By.empty 0 0
+        module Bytes = struct
+          let init ctx =
+            F.Bytes.with_outlen_and_key ctx D.digest_size By.empty 0 0
 
-                let update = F.Bytes.update
+          let update = F.Bytes.update
 
-                let finalize = F.Bytes.finalize
-              end
+          let finalize = F.Bytes.finalize
+        end
 
-              let ctx_size () = F.ctx_size ()
-            end)
-            (D)
+        let ctx_size () = F.ctx_size ()
+      end)
+      (D)
 
   type outer = t
 
@@ -579,21 +580,23 @@ module RMD160 : S =
 module Make_BLAKE2B (D : sig
   val digest_size : int
 end) : S = struct
-  include Make_BLAKE2
-            (Native.BLAKE2B)
-            (struct
-              let digest_size, block_size = (D.digest_size, 128)
-            end)
+  include
+    Make_BLAKE2
+      (Native.BLAKE2B)
+      (struct
+        let digest_size, block_size = (D.digest_size, 128)
+      end)
 end
 
 module Make_BLAKE2S (D : sig
   val digest_size : int
 end) : S = struct
-  include Make_BLAKE2
-            (Native.BLAKE2S)
-            (struct
-              let digest_size, block_size = (D.digest_size, 64)
-            end)
+  include
+    Make_BLAKE2
+      (Native.BLAKE2S)
+      (struct
+        let digest_size, block_size = (D.digest_size, 64)
+      end)
 end
 
 type 'k hash =

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -348,22 +348,22 @@ module Make_BLAKE2 (H : Hash_BLAKE2) (D : Desc) = struct
       failwith "Invalid digest_size:%d to make a BLAKE2{S,B} implementation"
         D.digest_size
 
-  include Make
-            (struct
-              type ctx = H.ctx
+  include
+    Make
+      (struct
+        type ctx = H.ctx
 
-              let init () =
-                H.with_outlen_and_bytes_key D.digest_size By.empty 0 0
+        let init () = H.with_outlen_and_bytes_key D.digest_size By.empty 0 0
 
-              let unsafe_feed_bytes = H.unsafe_feed_bytes
+        let unsafe_feed_bytes = H.unsafe_feed_bytes
 
-              let unsafe_feed_bigstring = H.unsafe_feed_bigstring
+        let unsafe_feed_bigstring = H.unsafe_feed_bigstring
 
-              let unsafe_get = H.unsafe_get
+        let unsafe_get = H.unsafe_get
 
-              let dup = H.dup
-            end)
-            (D)
+        let dup = H.dup
+      end)
+      (D)
 
   type outer = t
 
@@ -536,21 +536,23 @@ module RMD160 : S =
 module Make_BLAKE2B (D : sig
   val digest_size : int
 end) : S = struct
-  include Make_BLAKE2
-            (Baijiu_blake2b.Unsafe)
-            (struct
-              let digest_size, block_size = (D.digest_size, 128)
-            end)
+  include
+    Make_BLAKE2
+      (Baijiu_blake2b.Unsafe)
+      (struct
+        let digest_size, block_size = (D.digest_size, 128)
+      end)
 end
 
 module Make_BLAKE2S (D : sig
   val digest_size : int
 end) : S = struct
-  include Make_BLAKE2
-            (Baijiu_blake2s.Unsafe)
-            (struct
-              let digest_size, block_size = (D.digest_size, 64)
-            end)
+  include
+    Make_BLAKE2
+      (Baijiu_blake2s.Unsafe)
+      (struct
+        let digest_size, block_size = (D.digest_size, 64)
+      end)
 end
 
 type 'k hash =

--- a/test/test.ml
+++ b/test/test.ml
@@ -314,7 +314,8 @@ module BLAKE2 = struct
       | _ -> raise (Invalid_argument "of_hex") in
     let wsp = function ' ' | '\t' | '\r' | '\n' -> true | _ -> false in
     fold_s
-      (fun (res, i, acc) -> function chr when wsp chr -> (res, i, acc)
+      (fun (res, i, acc) -> function
+        | chr when wsp chr -> (res, i, acc)
         | chr ->
         match (acc, code chr) with
         | None, x -> (res, i, Some (x lsl 4))


### PR DESCRIPTION
Hi, this pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main changes in this diff are:

- the indentation of module includes has been fixed;
- the cases of anonymous functions are all properly broken.

Let me now if you notice any regressions.