### PR TITLE
ocamlformat: upgrade to 0.20.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,7 +1,7 @@
-version = 0.19.0
+version = 0.20.1
+profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
-indicate-multiline-delimiters=no
 nested-match=align
 sequence-style=separator
 break-before-in=auto

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -1,7 +1,5 @@
 open Mirage
 
 let main = foreign "Unikernel.Make" (console @-> job)
-
 let packages = [ package "digestif" ]
-
 let () = register ~packages "digestif-test" [ main $ default_console ]

--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -5,11 +5,8 @@ type bigstring =
   Bigarray_compat.Array1.t
 
 type 'a iter = ('a -> unit) -> unit
-
 type 'a compare = 'a -> 'a -> int
-
 type 'a equal = 'a -> 'a -> bool
-
 type 'a pp = Format.formatter -> 'a -> unit
 
 module Native = Digestif_native
@@ -24,83 +21,45 @@ module type S = sig
   val digest_size : int
 
   type ctx
-
   type t
 
   val empty : ctx
-
   val init : unit -> ctx
-
   val feed_bytes : ctx -> ?off:int -> ?len:int -> Bytes.t -> ctx
-
   val feed_string : ctx -> ?off:int -> ?len:int -> String.t -> ctx
-
   val feed_bigstring : ctx -> ?off:int -> ?len:int -> bigstring -> ctx
-
   val feedi_bytes : ctx -> Bytes.t iter -> ctx
-
   val feedi_string : ctx -> String.t iter -> ctx
-
   val feedi_bigstring : ctx -> bigstring iter -> ctx
-
   val get : ctx -> t
-
   val digest_bytes : ?off:int -> ?len:int -> Bytes.t -> t
-
   val digest_string : ?off:int -> ?len:int -> String.t -> t
-
   val digest_bigstring : ?off:int -> ?len:int -> bigstring -> t
-
   val digesti_bytes : Bytes.t iter -> t
-
   val digesti_string : String.t iter -> t
-
   val digesti_bigstring : bigstring iter -> t
-
   val digestv_bytes : Bytes.t list -> t
-
   val digestv_string : String.t list -> t
-
   val digestv_bigstring : bigstring list -> t
-
   val hmac_bytes : key:string -> ?off:int -> ?len:int -> Bytes.t -> t
-
   val hmac_string : key:string -> ?off:int -> ?len:int -> String.t -> t
-
   val hmac_bigstring : key:string -> ?off:int -> ?len:int -> bigstring -> t
-
   val hmaci_bytes : key:string -> Bytes.t iter -> t
-
   val hmaci_string : key:string -> String.t iter -> t
-
   val hmaci_bigstring : key:string -> bigstring iter -> t
-
   val hmacv_bytes : key:string -> Bytes.t list -> t
-
   val hmacv_string : key:string -> String.t list -> t
-
   val hmacv_bigstring : key:string -> bigstring list -> t
-
   val unsafe_compare : t compare
-
   val equal : t equal
-
   val pp : t pp
-
   val of_hex : string -> t
-
   val of_hex_opt : string -> t option
-
   val consistent_of_hex : string -> t
-
   val consistent_of_hex_opt : string -> t option
-
   val to_hex : t -> string
-
   val of_raw_string : string -> t
-
   val of_raw_string_opt : string -> t option
-
   val to_raw_string : t -> string
 end
 
@@ -108,21 +67,13 @@ module type MAC = sig
   type t
 
   val mac_bytes : key:string -> ?off:int -> ?len:int -> Bytes.t -> t
-
   val mac_string : key:string -> ?off:int -> ?len:int -> String.t -> t
-
   val mac_bigstring : key:string -> ?off:int -> ?len:int -> bigstring -> t
-
   val maci_bytes : key:string -> Bytes.t iter -> t
-
   val maci_string : key:string -> String.t iter -> t
-
   val maci_bigstring : key:string -> bigstring iter -> t
-
   val macv_bytes : key:string -> Bytes.t list -> t
-
   val macv_string : key:string -> String.t list -> t
-
   val macv_bigstring : key:string -> bigstring list -> t
 end
 
@@ -131,17 +82,13 @@ module type Foreign = sig
 
   module Bigstring : sig
     val init : ctx -> unit
-
     val update : ctx -> ba -> int -> int -> unit
-
     val finalize : ctx -> ba -> int -> unit
   end
 
   module Bytes : sig
     val init : ctx -> unit
-
     val update : ctx -> st -> int -> int -> unit
-
     val finalize : ctx -> st -> int -> unit
   end
 
@@ -150,15 +97,12 @@ end
 
 module type Desc = sig
   val block_size : int
-
   val digest_size : int
 end
 
 module Unsafe (F : Foreign) (D : Desc) = struct
   let block_size = D.block_size
-
   and digest_size = D.digest_size
-
   and ctx_size = F.ctx_size ()
 
   let init () =
@@ -205,7 +149,6 @@ end
 
 module Core (F : Foreign) (D : Desc) = struct
   type t = string
-
   type ctx = Native.ctx
 
   include Unsafe (F) (D)
@@ -250,21 +193,13 @@ module Core (F : Foreign) (D : Desc) = struct
     t
 
   let digest_bytes ?off ?len buf = feed_bytes empty ?off ?len buf |> get
-
   let digest_string ?off ?len buf = feed_string empty ?off ?len buf |> get
-
   let digest_bigstring ?off ?len buf = feed_bigstring empty ?off ?len buf |> get
-
   let digesti_bytes iter = feedi_bytes empty iter |> get
-
   let digesti_string iter = feedi_string empty iter |> get
-
   let digesti_bigstring iter = feedi_bigstring empty iter |> get
-
   let digestv_bytes lst = digesti_bytes (fun f -> List.iter f lst)
-
   let digestv_string lst = digesti_string (fun f -> List.iter f lst)
-
   let digestv_bigstring lst = digesti_bigstring (fun f -> List.iter f lst)
 end
 
@@ -272,7 +207,6 @@ module Make (F : Foreign) (D : Desc) = struct
   include Core (F) (D)
 
   let bytes_opad = By.make block_size '\x5c'
-
   let bytes_ipad = By.make block_size '\x36'
 
   let rec norm_bytes key =
@@ -337,7 +271,6 @@ module Make (F : Foreign) (D : Desc) = struct
     hmaci_bigstring ~key (fun f -> f buf)
 
   let hmacv_bytes ~key bufs = hmaci_bytes ~key (fun f -> List.iter f bufs)
-
   let hmacv_string ~key bufs = hmaci_string ~key (fun f -> List.iter f bufs)
 
   let hmacv_bigstring ~key bufs =
@@ -351,24 +284,18 @@ module type Foreign_BLAKE2 = sig
 
   module Bigstring : sig
     val update : ctx -> ba -> int -> int -> unit
-
     val finalize : ctx -> ba -> int -> unit
-
     val with_outlen_and_key : ctx -> int -> ba -> int -> int -> unit
   end
 
   module Bytes : sig
     val update : ctx -> st -> int -> int -> unit
-
     val finalize : ctx -> st -> int -> unit
-
     val with_outlen_and_key : ctx -> int -> st -> int -> int -> unit
   end
 
   val max_outlen : unit -> int
-
   val ctx_size : unit -> int
-
   val key_size : unit -> int
 end
 
@@ -387,7 +314,6 @@ module Make_BLAKE2 (F : Foreign_BLAKE2) (D : Desc) = struct
             F.Bigstring.with_outlen_and_key ctx D.digest_size Bi.empty 0 0
 
           let update = F.Bigstring.update
-
           let finalize = F.Bigstring.finalize
         end
 
@@ -396,7 +322,6 @@ module Make_BLAKE2 (F : Foreign_BLAKE2) (D : Desc) = struct
             F.Bytes.with_outlen_and_key ctx D.digest_size By.empty 0 0
 
           let update = F.Bytes.update
-
           let finalize = F.Bytes.finalize
         end
 
@@ -463,7 +388,6 @@ module Make_BLAKE2 (F : Foreign_BLAKE2) (D : Desc) = struct
       maci_bigstring ~key (fun f -> f buf)
 
     let macv_bytes ~key bufs = maci_bytes ~key (fun f -> List.iter f bufs)
-
     let macv_string ~key bufs = maci_string ~key (fun f -> List.iter f bufs)
 
     let macv_bigstring ~key bufs =
@@ -557,7 +481,6 @@ module WHIRLPOOL : S =
 
 module BLAKE2B : sig
   include S
-
   module Keyed : MAC with type t = t
 end =
   Make_BLAKE2
@@ -568,7 +491,6 @@ end =
 
 module BLAKE2S : sig
   include S
-
   module Keyed : MAC with type t = t
 end =
   Make_BLAKE2
@@ -624,33 +546,19 @@ type 'k hash =
   | BLAKE2S : BLAKE2S.t hash
 
 let md5 = MD5
-
 let sha1 = SHA1
-
 let rmd160 = RMD160
-
 let sha224 = SHA224
-
 let sha256 = SHA256
-
 let sha384 = SHA384
-
 let sha512 = SHA512
-
 let sha3_224 = SHA3_224
-
 let sha3_256 = SHA3_256
-
 let keccak_256 = KECCAK_256
-
 let sha3_384 = SHA3_384
-
 let sha3_512 = SHA3_512
-
 let whirlpool = WHIRLPOOL
-
 let blake2b = BLAKE2B
-
 let blake2s = BLAKE2S
 
 let module_of : type k. k hash -> (module S with type t = k) = function
@@ -779,31 +687,17 @@ let of_digest (type hash) (module H : S with type t = hash) (hash : H.t) :
   hash
 
 let of_md5 hash = hash
-
 let of_sha1 hash = hash
-
 let of_rmd160 hash = hash
-
 let of_sha224 hash = hash
-
 let of_sha256 hash = hash
-
 let of_sha384 hash = hash
-
 let of_sha512 hash = hash
-
 let of_sha3_224 hash = hash
-
 let of_sha3_256 hash = hash
-
 let of_keccak_256 hash = hash
-
 let of_sha3_384 hash = hash
-
 let of_sha3_512 hash = hash
-
 let of_whirlpool hash = hash
-
 let of_blake2b hash = hash
-
 let of_blake2s hash = hash

--- a/src-c/digestif_native.ml
+++ b/src-c/digestif_native.ml
@@ -16,13 +16,9 @@ module By = Digestif_by
 module Bi = Digestif_bi
 
 type off = int
-
 type size = int
-
 type ba = Bi.t
-
 type st = By.t
-
 type ctx = By.t
 
 let dup : ctx -> ctx = By.copy
@@ -416,7 +412,6 @@ module BLAKE2B = struct
   end
 
   external ctx_size : unit -> int = "caml_digestif_blake2b_ctx_size" [@@noalloc]
-
   external key_size : unit -> int = "caml_digestif_blake2b_key_size" [@@noalloc]
 
   external max_outlen : unit -> int = "caml_digestif_blake2b_max_outlen"
@@ -461,7 +456,6 @@ module BLAKE2S = struct
   end
 
   external ctx_size : unit -> int = "caml_digestif_blake2s_ctx_size" [@@noalloc]
-
   external key_size : unit -> int = "caml_digestif_blake2s_key_size" [@@noalloc]
 
   external max_outlen : unit -> int = "caml_digestif_blake2s_max_outlen"

--- a/src-ocaml/baijiu_blake2b.ml
+++ b/src-ocaml/baijiu_blake2b.ml
@@ -7,23 +7,14 @@ module Int32 = struct
   include Int32
 
   let ( lsl ) = Int32.shift_left
-
   let ( lsr ) = Int32.shift_right_logical
-
   let ( asr ) = Int32.shift_right
-
   let ( lor ) = Int32.logor
-
   let ( lxor ) = Int32.logxor
-
   let ( land ) = Int32.logand
-
   let lnot = Int32.lognot
-
   let ( + ) = Int32.add
-
   let rol32 a n = (a lsl n) lor (a lsr (32 - n))
-
   let ror32 a n = (a lsr n) lor (a lsl (32 - n))
 end
 
@@ -31,43 +22,27 @@ module Int64 = struct
   include Int64
 
   let ( land ) = Int64.logand
-
   let ( lsl ) = Int64.shift_left
-
   let ( lsr ) = Int64.shift_right_logical
-
   let ( lor ) = Int64.logor
-
   let ( asr ) = Int64.shift_right
-
   let ( lxor ) = Int64.logxor
-
   let ( + ) = Int64.add
-
   let rol64 a n = (a lsl n) lor (a lsr (64 - n))
-
   let ror64 a n = (a lsr n) lor (a lsl (64 - n))
 end
 
 module type S = sig
   type ctx
-
   type kind = [ `BLAKE2B ]
 
   val init : unit -> ctx
-
   val with_outlen_and_bytes_key : int -> By.t -> int -> int -> ctx
-
   val with_outlen_and_bigstring_key : int -> Bi.t -> int -> int -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
-
   val max_outlen : int
 end
 

--- a/src-ocaml/baijiu_blake2s.ml
+++ b/src-ocaml/baijiu_blake2s.ml
@@ -7,23 +7,14 @@ module Int32 = struct
   include Int32
 
   let ( lsl ) = Int32.shift_left
-
   let ( lsr ) = Int32.shift_right_logical
-
   let ( asr ) = Int32.shift_right
-
   let ( lor ) = Int32.logor
-
   let ( lxor ) = Int32.logxor
-
   let ( land ) = Int32.logand
-
   let lnot = Int32.lognot
-
   let ( + ) = Int32.add
-
   let rol32 a n = (a lsl n) lor (a lsr (32 - n))
-
   let ror32 a n = (a lsr n) lor (a lsl (32 - n))
 end
 
@@ -31,43 +22,27 @@ module Int64 = struct
   include Int64
 
   let ( land ) = Int64.logand
-
   let ( lsl ) = Int64.shift_left
-
   let ( lsr ) = Int64.shift_right_logical
-
   let ( lor ) = Int64.logor
-
   let ( asr ) = Int64.shift_right
-
   let ( lxor ) = Int64.logxor
-
   let ( + ) = Int64.add
-
   let rol64 a n = (a lsl n) lor (a lsr (64 - n))
-
   let ror64 a n = (a lsr n) lor (a lsl (64 - n))
 end
 
 module type S = sig
   type ctx
-
   type kind = [ `BLAKE2S ]
 
   val init : unit -> ctx
-
   val with_outlen_and_bytes_key : int -> By.t -> int -> int -> ctx
-
   val with_outlen_and_bigstring_key : int -> Bi.t -> int -> int -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
-
   val max_outlen : int
 end
 

--- a/src-ocaml/baijiu_keccak_256.ml
+++ b/src-ocaml/baijiu_keccak_256.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA3_256 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -29,12 +24,8 @@ module Unsafe : S = struct
   type nonrec ctx = ctx
 
   let init () = U.init 32
-
   let unsafe_get = unsafe_get
-
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_md5.ml
+++ b/src-ocaml/baijiu_md5.ml
@@ -5,23 +5,14 @@ module Int32 = struct
   include Int32
 
   let ( lsl ) = Int32.shift_left
-
   let ( lsr ) = Int32.shift_right_logical
-
   let ( asr ) = Int32.shift_right
-
   let ( lor ) = Int32.logor
-
   let ( lxor ) = Int32.logxor
-
   let ( land ) = Int32.logand
-
   let lnot = Int32.lognot
-
   let ( + ) = Int32.add
-
   let rol32 a n = (a lsl n) lor (a lsr (32 - n))
-
   let ror32 a n = (a lsr n) lor (a lsl (32 - n))
 end
 
@@ -29,29 +20,22 @@ module Int64 = struct
   include Int64
 
   let ( land ) = Int64.logand
-
   let ( lsl ) = Int64.shift_left
 end
 
 module type S = sig
   type kind = [ `MD5 ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int32 array }
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
 module Unsafe : S = struct
   type kind = [ `MD5 ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int32 array }
 
   let dup ctx = { size = ctx.size; b = By.copy ctx.b; h = Array.copy ctx.h }
@@ -65,11 +49,8 @@ module Unsafe : S = struct
     }
 
   let f1 x y z = Int32.(z lxor (x land (y lxor z)))
-
   let f2 x y z = f1 z x y
-
   let f3 x y z = Int32.(x lxor y lxor z)
-
   let f4 x y z = Int32.(y lxor (x lor lnot z))
 
   let md5_do_chunk :

--- a/src-ocaml/baijiu_rmd160.ml
+++ b/src-ocaml/baijiu_rmd160.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `RMD160 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -21,23 +16,14 @@ module Int32 = struct
   include Int32
 
   let ( lsl ) = Int32.shift_left
-
   let ( lsr ) = Int32.shift_right_logical
-
   let ( asr ) = Int32.shift_right
-
   let ( lor ) = Int32.logor
-
   let ( lxor ) = Int32.logxor
-
   let ( land ) = Int32.logand
-
   let lnot = Int32.lognot
-
   let ( + ) = Int32.add
-
   let rol32 a n = (a lsl n) lor (a lsr (32 - n))
-
   let ror32 a n = (a lsr n) lor (a lsl (32 - n))
 end
 
@@ -45,13 +31,11 @@ module Int64 = struct
   include Int64
 
   let ( land ) = Int64.logand
-
   let ( lsl ) = Int64.shift_left
 end
 
 module Unsafe : S = struct
   type kind = [ `RMD160 ]
-
   type ctx = { s : int32 array; mutable n : int; h : int32 array; b : Bytes.t }
 
   let dup ctx =
@@ -67,13 +51,9 @@ module Unsafe : S = struct
     }
 
   let f x y z = Int32.(x lxor y lxor z)
-
   let g x y z = Int32.(x land y lor (lnot x land z))
-
   let h x y z = Int32.(x lor lnot y lxor z)
-
   let i x y z = Int32.(x land z lor (y land lnot z))
-
   let j x y z = Int32.(x lxor (y lor lnot z))
 
   let ff a b c d e x s =

--- a/src-ocaml/baijiu_sha1.ml
+++ b/src-ocaml/baijiu_sha1.ml
@@ -5,19 +5,12 @@ module Int32 = struct
   include Int32
 
   let ( lsl ) = Int32.shift_left
-
   let ( lsr ) = Int32.shift_right_logical
-
   let ( asr ) = Int32.shift_right
-
   let ( lor ) = Int32.logor
-
   let ( lxor ) = Int32.logxor
-
   let ( land ) = Int32.logand
-
   let ( + ) = Int32.add
-
   let rol32 a n = (a lsl n) lor (a lsr (32 - n))
 end
 
@@ -25,29 +18,22 @@ module Int64 = struct
   include Int64
 
   let ( land ) = Int64.logand
-
   let ( lsl ) = Int64.shift_left
 end
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA1 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
 module Unsafe : S = struct
   type kind = [ `SHA1 ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int32 array }
 
   let dup ctx = { size = ctx.size; b = By.copy ctx.b; h = Array.copy ctx.h }
@@ -61,19 +47,12 @@ module Unsafe : S = struct
     }
 
   let f1 x y z = Int32.(z lxor (x land (y lxor z)))
-
   let f2 x y z = Int32.(x lxor y lxor z)
-
   let f3 x y z = Int32.((x land y) + (z land (x lxor y)))
-
   let f4 = f2
-
   let k1 = 0x5a827999l
-
   let k2 = 0x6ed9eba1l
-
   let k3 = 0x8f1bbcdcl
-
   let k4 = 0xca62c1d6l
 
   let sha1_do_chunk :

--- a/src-ocaml/baijiu_sha224.ml
+++ b/src-ocaml/baijiu_sha224.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA224 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -41,8 +36,6 @@ module Unsafe : S = struct
     By.sub res 0 28
 
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_sha256.ml
+++ b/src-ocaml/baijiu_sha256.ml
@@ -5,21 +5,13 @@ module Int32 = struct
   include Int32
 
   let ( lsl ) = Int32.shift_left
-
   let ( lsr ) = Int32.shift_right_logical
-
   let ( asr ) = Int32.shift_right
-
   let ( lor ) = Int32.logor
-
   let ( lxor ) = Int32.logxor
-
   let ( land ) = Int32.logand
-
   let ( + ) = Int32.add
-
   let rol32 a n = (a lsl n) lor (a lsr (32 - n))
-
   let ror32 a n = (a lsr n) lor (a lsl (32 - n))
 end
 
@@ -27,29 +19,22 @@ module Int64 = struct
   include Int64
 
   let ( land ) = Int64.logand
-
   let ( lsl ) = Int64.shift_left
 end
 
 module type S = sig
   type kind = [ `SHA256 ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int32 array }
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
 module Unsafe : S = struct
   type kind = [ `SHA256 ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int32 array }
 
   let dup ctx = { size = ctx.size; b = By.copy ctx.b; h = Array.copy ctx.h }
@@ -84,11 +69,8 @@ module Unsafe : S = struct
     |]
 
   let e0 x = Int32.(ror32 x 2 lxor ror32 x 13 lxor ror32 x 22)
-
   let e1 x = Int32.(ror32 x 6 lxor ror32 x 11 lxor ror32 x 25)
-
   let s0 x = Int32.(ror32 x 7 lxor ror32 x 18 lxor (x lsr 3))
-
   let s1 x = Int32.(ror32 x 17 lxor ror32 x 19 lxor (x lsr 10))
 
   let sha256_do_chunk :

--- a/src-ocaml/baijiu_sha3.ml
+++ b/src-ocaml/baijiu_sha3.ml
@@ -2,28 +2,19 @@ module By = Digestif_by
 module Bi = Digestif_bi
 
 let nist_padding = 0x06L
-
 let keccak_padding = 0x01L
 
 module Int64 = struct
   include Int64
 
   let ( lsl ) = Int64.shift_left
-
   let ( lsr ) = Int64.shift_right_logical
-
   let ( asr ) = Int64.shift_right
-
   let ( lor ) = Int64.logor
-
   let ( land ) = Int64.logand
-
   let ( lxor ) = Int64.logxor
-
   let ( + ) = Int64.add
-
   let ror64 a n = (a lsr n) lor (a lsl (64 - n))
-
   let rol64 a n = (a lsl n) lor (a lsr (64 - n))
 end
 

--- a/src-ocaml/baijiu_sha384.ml
+++ b/src-ocaml/baijiu_sha384.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA384 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -42,8 +37,6 @@ module Unsafe : S = struct
     By.sub res 0 48
 
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_sha3_224.ml
+++ b/src-ocaml/baijiu_sha3_224.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA3_224 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -29,12 +24,8 @@ module Unsafe : S = struct
   type nonrec ctx = ctx
 
   let init () = U.init 28
-
   let unsafe_get = unsafe_get
-
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_sha3_256.ml
+++ b/src-ocaml/baijiu_sha3_256.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA3_256 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -29,12 +24,8 @@ module Unsafe : S = struct
   type nonrec ctx = ctx
 
   let init () = U.init 32
-
   let unsafe_get = unsafe_get
-
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_sha3_384.ml
+++ b/src-ocaml/baijiu_sha3_384.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA3_384 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -29,12 +24,8 @@ module Unsafe : S = struct
   type nonrec ctx = ctx
 
   let init () = U.init 48
-
   let unsafe_get = unsafe_get
-
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_sha3_512.ml
+++ b/src-ocaml/baijiu_sha3_512.ml
@@ -3,17 +3,12 @@ module Bi = Digestif_bi
 
 module type S = sig
   type ctx
-
   type kind = [ `SHA3_512 ]
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -29,12 +24,8 @@ module Unsafe : S = struct
   type nonrec ctx = ctx
 
   let init () = U.init 64
-
   let unsafe_get = unsafe_get
-
   let dup = dup
-
   let unsafe_feed_bytes = unsafe_feed_bytes
-
   let unsafe_feed_bigstring = unsafe_feed_bigstring
 end

--- a/src-ocaml/baijiu_sha512.ml
+++ b/src-ocaml/baijiu_sha512.ml
@@ -5,43 +5,29 @@ module Int64 = struct
   include Int64
 
   let ( lsl ) = Int64.shift_left
-
   let ( lsr ) = Int64.shift_right_logical
-
   let ( asr ) = Int64.shift_right
-
   let ( lor ) = Int64.logor
-
   let ( land ) = Int64.logand
-
   let ( lxor ) = Int64.logxor
-
   let ( + ) = Int64.add
-
   let ror64 a n = (a lsr n) lor (a lsl (64 - n))
-
   let rol64 a n = (a lsl n) lor (a lsr (64 - n))
 end
 
 module type S = sig
   type kind = [ `SHA512 ]
-
   type ctx = { mutable size : int64 array; b : Bytes.t; h : int64 array }
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
 module Unsafe : S = struct
   type kind = [ `SHA512 ]
-
   type ctx = { mutable size : int64 array; b : Bytes.t; h : int64 array }
 
   let dup ctx =
@@ -92,11 +78,8 @@ module Unsafe : S = struct
     |]
 
   let e0 x = Int64.(ror64 x 28 lxor ror64 x 34 lxor ror64 x 39)
-
   let e1 x = Int64.(ror64 x 14 lxor ror64 x 18 lxor ror64 x 41)
-
   let s0 x = Int64.(ror64 x 1 lxor ror64 x 8 lxor (x lsr 7))
-
   let s1 x = Int64.(ror64 x 19 lxor ror64 x 61 lxor (x lsr 6))
 
   let sha512_do_chunk :

--- a/src-ocaml/baijiu_whirlpool.ml
+++ b/src-ocaml/baijiu_whirlpool.ml
@@ -5,43 +5,29 @@ module Int64 = struct
   include Int64
 
   let ( lsl ) = Int64.shift_left
-
   let ( lsr ) = Int64.shift_right_logical
-
   let ( asr ) = Int64.shift_right
-
   let ( lor ) = Int64.logor
-
   let ( land ) = Int64.logand
-
   let ( lxor ) = Int64.logxor
-
   let ( + ) = Int64.add
-
   let ror64 a n = (a lsr n) lor (a lsl (64 - n))
-
   let rol64 a n = (a lsl n) lor (a lsr (64 - n))
 end
 
 module type S = sig
   type kind = [ `WHIRLPOOL ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int64 array }
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
 module Unsafe : S = struct
   type kind = [ `WHIRLPOOL ]
-
   type ctx = { mutable size : int64; b : Bytes.t; h : int64 array }
 
   let dup ctx = { size = ctx.size; b = By.copy ctx.b; h = Array.copy ctx.h }

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -5,11 +5,8 @@ type bigstring =
   Bigarray_compat.Array1.t
 
 type 'a iter = ('a -> unit) -> unit
-
 type 'a compare = 'a -> 'a -> int
-
 type 'a equal = 'a -> 'a -> bool
-
 type 'a pp = Format.formatter -> 'a -> unit
 
 module By = Digestif_by
@@ -23,83 +20,45 @@ module type S = sig
   val digest_size : int
 
   type ctx
-
   type t
 
   val empty : ctx
-
   val init : unit -> ctx
-
   val feed_bytes : ctx -> ?off:int -> ?len:int -> Bytes.t -> ctx
-
   val feed_string : ctx -> ?off:int -> ?len:int -> String.t -> ctx
-
   val feed_bigstring : ctx -> ?off:int -> ?len:int -> bigstring -> ctx
-
   val feedi_bytes : ctx -> Bytes.t iter -> ctx
-
   val feedi_string : ctx -> String.t iter -> ctx
-
   val feedi_bigstring : ctx -> bigstring iter -> ctx
-
   val get : ctx -> t
-
   val digest_bytes : ?off:int -> ?len:int -> Bytes.t -> t
-
   val digest_string : ?off:int -> ?len:int -> String.t -> t
-
   val digest_bigstring : ?off:int -> ?len:int -> bigstring -> t
-
   val digesti_bytes : Bytes.t iter -> t
-
   val digesti_string : String.t iter -> t
-
   val digesti_bigstring : bigstring iter -> t
-
   val digestv_bytes : Bytes.t list -> t
-
   val digestv_string : String.t list -> t
-
   val digestv_bigstring : bigstring list -> t
-
   val hmac_bytes : key:string -> ?off:int -> ?len:int -> Bytes.t -> t
-
   val hmac_string : key:string -> ?off:int -> ?len:int -> String.t -> t
-
   val hmac_bigstring : key:string -> ?off:int -> ?len:int -> bigstring -> t
-
   val hmaci_bytes : key:string -> Bytes.t iter -> t
-
   val hmaci_string : key:string -> String.t iter -> t
-
   val hmaci_bigstring : key:string -> bigstring iter -> t
-
   val hmacv_bytes : key:string -> Bytes.t list -> t
-
   val hmacv_string : key:string -> String.t list -> t
-
   val hmacv_bigstring : key:string -> bigstring list -> t
-
   val unsafe_compare : t compare
-
   val equal : t equal
-
   val pp : t pp
-
   val of_hex : string -> t
-
   val of_hex_opt : string -> t option
-
   val consistent_of_hex : string -> t
-
   val consistent_of_hex_opt : string -> t option
-
   val to_hex : t -> string
-
   val of_raw_string : string -> t
-
   val of_raw_string_opt : string -> t option
-
   val to_raw_string : t -> string
 end
 
@@ -107,27 +66,18 @@ module type MAC = sig
   type t
 
   val mac_bytes : key:string -> ?off:int -> ?len:int -> Bytes.t -> t
-
   val mac_string : key:string -> ?off:int -> ?len:int -> String.t -> t
-
   val mac_bigstring : key:string -> ?off:int -> ?len:int -> bigstring -> t
-
   val maci_bytes : key:string -> Bytes.t iter -> t
-
   val maci_string : key:string -> String.t iter -> t
-
   val maci_bigstring : key:string -> bigstring iter -> t
-
   val macv_bytes : key:string -> Bytes.t list -> t
-
   val macv_string : key:string -> String.t list -> t
-
   val macv_bigstring : key:string -> bigstring list -> t
 end
 
 module type Desc = sig
   val digest_size : int
-
   val block_size : int
 end
 
@@ -135,13 +85,9 @@ module type Hash = sig
   type ctx
 
   val init : unit -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
 end
 
@@ -149,11 +95,8 @@ module Unsafe (Hash : Hash) (D : Desc) = struct
   open Hash
 
   let digest_size = D.digest_size
-
   let block_size = D.block_size
-
   let empty = init ()
-
   let init = init
 
   let unsafe_feed_bytes ctx ?off ?len buf =
@@ -186,7 +129,6 @@ end
 
 module Core (Hash : Hash) (D : Desc) = struct
   type t = string
-
   type ctx = Hash.ctx
 
   include Unsafe (Hash) (D)
@@ -231,21 +173,13 @@ module Core (Hash : Hash) (D : Desc) = struct
     t
 
   let digest_bytes ?off ?len buf = feed_bytes empty ?off ?len buf |> get
-
   let digest_string ?off ?len buf = feed_string empty ?off ?len buf |> get
-
   let digest_bigstring ?off ?len buf = feed_bigstring empty ?off ?len buf |> get
-
   let digesti_bytes iter = feedi_bytes empty iter |> get
-
   let digesti_string iter = feedi_string empty iter |> get
-
   let digesti_bigstring iter = feedi_bigstring empty iter |> get
-
   let digestv_bytes lst = digesti_bytes (fun f -> List.iter f lst)
-
   let digestv_string lst = digesti_string (fun f -> List.iter f lst)
-
   let digestv_bigstring lst = digesti_bigstring (fun f -> List.iter f lst)
 end
 
@@ -253,7 +187,6 @@ module Make (H : Hash) (D : Desc) = struct
   include Core (H) (D)
 
   let bytes_opad = By.init block_size (fun _ -> '\x5c')
-
   let bytes_ipad = By.init block_size (fun _ -> '\x36')
 
   let rec norm_bytes key =
@@ -318,7 +251,6 @@ module Make (H : Hash) (D : Desc) = struct
     hmaci_bigstring ~key (fun f -> f buf)
 
   let hmacv_bytes ~key bufs = hmaci_bytes ~key (fun f -> List.iter f bufs)
-
   let hmacv_string ~key bufs = hmaci_string ~key (fun f -> List.iter f bufs)
 
   let hmacv_bigstring ~key bufs =
@@ -329,15 +261,10 @@ module type Hash_BLAKE2 = sig
   type ctx
 
   val with_outlen_and_bytes_key : int -> By.t -> int -> int -> ctx
-
   val unsafe_feed_bytes : ctx -> By.t -> int -> int -> unit
-
   val unsafe_feed_bigstring : ctx -> Bi.t -> int -> int -> unit
-
   val unsafe_get : ctx -> By.t
-
   val dup : ctx -> ctx
-
   val max_outlen : int
 end
 
@@ -354,13 +281,9 @@ module Make_BLAKE2 (H : Hash_BLAKE2) (D : Desc) = struct
         type ctx = H.ctx
 
         let init () = H.with_outlen_and_bytes_key D.digest_size By.empty 0 0
-
         let unsafe_feed_bytes = H.unsafe_feed_bytes
-
         let unsafe_feed_bigstring = H.unsafe_feed_bigstring
-
         let unsafe_get = H.unsafe_get
-
         let dup = H.dup
       end)
       (D)
@@ -419,7 +342,6 @@ module Make_BLAKE2 (H : Hash_BLAKE2) (D : Desc) = struct
       maci_bigstring ~key (fun f -> f buf)
 
     let macv_bytes ~key bufs = maci_bytes ~key (fun f -> List.iter f bufs)
-
     let macv_string ~key bufs = maci_string ~key (fun f -> List.iter f bufs)
 
     let macv_bigstring ~key bufs =
@@ -513,7 +435,6 @@ module WHIRLPOOL : S =
 
 module BLAKE2B : sig
   include S
-
   module Keyed : MAC with type t = t
 end =
   Make_BLAKE2
@@ -524,7 +445,6 @@ end =
 
 module BLAKE2S : sig
   include S
-
   module Keyed : MAC with type t = t
 end =
   Make_BLAKE2
@@ -580,33 +500,19 @@ type 'k hash =
   | BLAKE2S : BLAKE2S.t hash
 
 let md5 = MD5
-
 let sha1 = SHA1
-
 let rmd160 = RMD160
-
 let sha224 = SHA224
-
 let sha256 = SHA256
-
 let sha384 = SHA384
-
 let sha512 = SHA512
-
 let sha3_224 = SHA3_224
-
 let sha3_256 = SHA3_256
-
 let keccak_256 = KECCAK_256
-
 let sha3_384 = SHA3_384
-
 let sha3_512 = SHA3_512
-
 let whirlpool = WHIRLPOOL
-
 let blake2b = BLAKE2B
-
 let blake2s = BLAKE2S
 
 let module_of : type k. k hash -> (module S with type t = k) = function
@@ -735,31 +641,17 @@ let of_digest (type hash) (module H : S with type t = hash) (hash : H.t) :
   hash
 
 let of_md5 hash = hash
-
 let of_sha1 hash = hash
-
 let of_rmd160 hash = hash
-
 let of_sha224 hash = hash
-
 let of_sha256 hash = hash
-
 let of_sha384 hash = hash
-
 let of_sha512 hash = hash
-
 let of_sha3_224 hash = hash
-
 let of_sha3_256 hash = hash
-
 let of_keccak_256 hash = hash
-
 let of_sha3_384 hash = hash
-
 let of_sha3_512 hash = hash
-
 let of_whirlpool hash = hash
-
 let of_blake2b hash = hash
-
 let of_blake2s hash = hash

--- a/src-ocaml/xor.ml
+++ b/src-ocaml/xor.ml
@@ -8,13 +8,9 @@ module type BUFFER = sig
   type t
 
   val length : t -> int
-
   val sub : t -> int -> int -> t
-
   val copy : t -> t
-
   val benat_to_cpu : t -> int -> nativeint
-
   val cpu_to_benat : t -> int -> nativeint -> unit
 end
 

--- a/src/digestif.mli
+++ b/src/digestif.mli
@@ -13,9 +13,7 @@ type 'a iter = ('a -> unit) -> unit
     - [let iter_list : 'a list -> 'a iter = fun l f -> List.iter f l] *)
 
 type 'a compare = 'a -> 'a -> int
-
 type 'a equal = 'a -> 'a -> bool
-
 type 'a pp = Format.formatter -> 'a -> unit
 
 module type S = sig
@@ -23,7 +21,6 @@ module type S = sig
   (** Size of hash results, in bytes. *)
 
   type ctx
-
   type t
 
   val empty : ctx
@@ -175,34 +172,21 @@ module type MAC = sig
   type t
 
   val mac_bytes : key:string -> ?off:int -> ?len:int -> Bytes.t -> t
-
   val mac_string : key:string -> ?off:int -> ?len:int -> String.t -> t
-
   val mac_bigstring : key:string -> ?off:int -> ?len:int -> bigstring -> t
-
   val maci_bytes : key:string -> Bytes.t iter -> t
-
   val maci_string : key:string -> String.t iter -> t
-
   val maci_bigstring : key:string -> bigstring iter -> t
-
   val macv_bytes : key:string -> Bytes.t list -> t
-
   val macv_string : key:string -> String.t list -> t
-
   val macv_bigstring : key:string -> bigstring list -> t
 end
 
 module MD5 : S
-
 module SHA1 : S
-
 module SHA224 : S
-
 module SHA256 : S
-
 module SHA384 : S
-
 module SHA512 : S
 
 module SHA3_224 : S
@@ -237,13 +221,11 @@ module WHIRLPOOL : S
 
 module BLAKE2B : sig
   include S
-
   module Keyed : MAC with type t = t
 end
 
 module BLAKE2S : sig
   include S
-
   module Keyed : MAC with type t = t
 end
 
@@ -278,94 +260,54 @@ type 'k hash =
   | BLAKE2S : BLAKE2S.t hash
 
 val md5 : MD5.t hash
-
 val sha1 : SHA1.t hash
-
 val rmd160 : RMD160.t hash
-
 val sha224 : SHA224.t hash
-
 val sha256 : SHA256.t hash
-
 val sha384 : SHA384.t hash
-
 val sha512 : SHA512.t hash
-
 val sha3_224 : SHA3_224.t hash
-
 val sha3_256 : SHA3_256.t hash
-
 val keccak_256 : KECCAK_256.t hash
-
 val sha3_384 : SHA3_384.t hash
-
 val sha3_512 : SHA3_512.t hash
-
 val whirlpool : WHIRLPOOL.t hash
-
 val blake2b : BLAKE2B.t hash
-
 val blake2s : BLAKE2S.t hash
 
 type 'kind t
 
 val module_of : 'k hash -> (module S with type t = 'k)
-
 val digest_bytes : 'k hash -> Bytes.t -> 'k t
-
 val digest_string : 'k hash -> String.t -> 'k t
-
 val digest_bigstring : 'k hash -> bigstring -> 'k t
-
 val digesti_bytes : 'k hash -> Bytes.t iter -> 'k t
-
 val digesti_string : 'k hash -> String.t iter -> 'k t
-
 val digesti_bigstring : 'k hash -> bigstring iter -> 'k t
-
 val hmaci_bytes : 'k hash -> key:string -> Bytes.t iter -> 'k t
-
 val hmaci_string : 'k hash -> key:string -> String.t iter -> 'k t
-
 val hmaci_bigstring : 'k hash -> key:string -> bigstring iter -> 'k t
-
 val pp : 'k hash -> 'k t pp
-
 val equal : 'k hash -> 'k t equal
-
 val unsafe_compare : 'k hash -> 'k t compare
-
 val to_hex : 'k hash -> 'k t -> string
-
 val of_hex : 'k hash -> string -> 'k t
-
 val of_hex_opt : 'k hash -> string -> 'k t option
-
 val consistent_of_hex : 'k hash -> string -> 'k t
-
 val consistent_of_hex_opt : 'k hash -> string -> 'k t option
-
 val of_raw_string : 'k hash -> string -> 'k t
-
 val of_raw_string_opt : 'k hash -> string -> 'k t option
-
 val to_raw_string : 'k hash -> 'k t -> string
-
 val of_digest : (module S with type t = 'hash) -> 'hash -> 'hash t
-
 val of_md5 : MD5.t -> MD5.t t
-
 val of_sha1 : SHA1.t -> SHA1.t t
 
 val of_rmd160 : RMD160.t -> RMD160.t t
 (** @since 0.4 *)
 
 val of_sha224 : SHA224.t -> SHA224.t t
-
 val of_sha256 : SHA256.t -> SHA256.t t
-
 val of_sha384 : SHA384.t -> SHA384.t t
-
 val of_sha512 : SHA512.t -> SHA512.t t
 
 val of_sha3_224 : SHA3_224.t -> SHA3_224.t t
@@ -387,5 +329,4 @@ val of_whirlpool : WHIRLPOOL.t -> WHIRLPOOL.t t
 (** @since 0.7.1 *)
 
 val of_blake2b : BLAKE2B.t -> BLAKE2B.t t
-
 val of_blake2s : BLAKE2S.t -> BLAKE2S.t t

--- a/src/digestif_bi.ml
+++ b/src/digestif_bi.ml
@@ -3,13 +3,9 @@ open Bigarray_compat
 type t = (char, int8_unsigned_elt, c_layout) Array1.t
 
 let create n = Array1.create Char c_layout n
-
 let length = Array1.dim
-
 let sub = Array1.sub
-
 let empty = Array1.create Char c_layout 0
-
 let get = Array1.get
 
 let copy t =
@@ -25,7 +21,6 @@ let init l f =
   v
 
 external unsafe_get_32 : t -> int -> int32 = "%caml_bigstring_get32u"
-
 external unsafe_get_64 : t -> int -> int64 = "%caml_bigstring_get64u"
 
 let unsafe_get_nat : t -> int -> nativeint =
@@ -35,7 +30,6 @@ let unsafe_get_nat : t -> int -> nativeint =
   else Int64.to_nativeint @@ unsafe_get_64 s i
 
 external unsafe_set_32 : t -> int -> int32 -> unit = "%caml_bigstring_set32u"
-
 external unsafe_set_64 : t -> int -> int64 -> unit = "%caml_bigstring_set64u"
 
 let unsafe_set_nat : t -> int -> nativeint -> unit =
@@ -52,9 +46,7 @@ let blit_from_bytes src src_off dst dst_off len =
   done
 
 external swap32 : int32 -> int32 = "%bswap_int32"
-
 external swap64 : int64 -> int64 = "%bswap_int64"
-
 external swapnat : nativeint -> nativeint = "%bswap_native"
 
 let cpu_to_be32 s i v =

--- a/src/digestif_by.ml
+++ b/src/digestif_by.ml
@@ -1,7 +1,6 @@
 include Bytes
 
 external unsafe_get_32 : t -> int -> int32 = "%caml_string_get32u"
-
 external unsafe_get_64 : t -> int -> int64 = "%caml_string_get64u"
 
 let unsafe_get_nat : t -> int -> nativeint =
@@ -11,7 +10,6 @@ let unsafe_get_nat : t -> int -> nativeint =
   else Int64.to_nativeint @@ unsafe_get_64 s i
 
 external unsafe_set_32 : t -> int -> int32 -> unit = "%caml_string_set32u"
-
 external unsafe_set_64 : t -> int -> int64 -> unit = "%caml_string_set64u"
 
 let unsafe_set_nat : t -> int -> nativeint -> unit =
@@ -33,9 +31,7 @@ let rpad a size x =
   b
 
 external swap32 : int32 -> int32 = "%bswap_int32"
-
 external swap64 : int64 -> int64 = "%bswap_int64"
-
 external swapnat : nativeint -> nativeint = "%bswap_native"
 
 let cpu_to_be32 s i v =

--- a/src/digestif_eq.ml
+++ b/src/digestif_eq.ml
@@ -3,8 +3,6 @@ module Make (D : sig
 end) =
 struct
   let _ = D.digest_size
-
   let equal a b = Eqaf.equal a b
-
   let unsafe_compare a b = String.compare a b
 end

--- a/test/conv/test_conv.ml
+++ b/test/conv/test_conv.ml
@@ -1,13 +1,9 @@
 external random_seed : unit -> int array = "caml_sys_random_seed"
 
 let seed = random_seed ()
-
 let () = Random.full_init seed
-
 let () = Fmt.epr "seed: %a.\n%!" Fmt.(Dump.array int) seed
-
 let strf = Fmt.str
-
 let invalid_arg = Fmt.invalid_arg
 
 let list_init f l =
@@ -23,7 +19,6 @@ let random_string length _ =
   rs
 
 let hashes = list_init (random_string Digestif.SHA1.digest_size) 32
-
 let hashes = List.map Digestif.SHA1.of_raw_string hashes
 
 let consistent_hex =

--- a/test/test.ml
+++ b/test/test.ml
@@ -36,9 +36,7 @@ let title : type a k. [ `HMAC | `Digest ] -> k Digestif.hash -> a s -> string =
   Fmt.str "%a:%a:%a" pp_computation computation pp_hash hash pp_input input
 
 let bytes = Bytes
-
 let string = String
-
 let bigstring = Bigstring
 
 let test_hmac :
@@ -302,7 +300,6 @@ let results_blake2s =
 
 module BLAKE2 = struct
   let input_blake2b_file = "../blake2b.test"
-
   let input_blake2s_file = "../blake2s.test"
 
   let fold_s f a s =

--- a/test/test_runes.ml
+++ b/test/test_runes.ml
@@ -79,9 +79,7 @@ let parse_lL_args args =
   go [] args
 
 let is_path = function Path _ -> true | Library _ -> false
-
 let prj_path = function Path x -> x | _ -> assert false
-
 let prj_libraries = function Library x -> x | _ -> assert false
 
 let libraries_exist args =
@@ -147,7 +145,6 @@ let run () =
   >>= fun () -> R.ok ()
 
 let exit_success = 0
-
 let exit_failure = 1
 
 let () =


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- option `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions
- the `.ocamlformat` file has been simplified using the conventional profile