### PR TITLE
mark sha3_keccakf as static to avoid this symbol being exposed

### DIFF
--- a/src-c/native/sha3.c
+++ b/src-c/native/sha3.c
@@ -12,7 +12,7 @@
 
 // update the state with given number of rounds
 
-void sha3_keccakf(uint64_t st[25])
+static void sha3_keccakf(uint64_t st[25])
 {
     // constants
     const uint64_t keccakf_rndc[24] = {


### PR DESCRIPTION
now, a readelf -s libdigestif_freestanding_stubs.a only returns
digestif_* and caml_digestif_* symbols -- so everything is nicely prefixed.