### PR TITLE
Remove shebang for platforms that `env` is not located on `/usr/bin`

### DIFF
--- a/digestif.opam
+++ b/digestif.opam
@@ -29,12 +29,12 @@ We provides implementation of:
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "./install/install.ml" ]
+  [ "ocaml" "./install/install.ml" ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 install:  [
   [ "dune" "install" "-p" name ] {with-test}
-  [ "./test/test_runes.ml" ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
 ]
 
 depends: [

--- a/install/install.ml
+++ b/install/install.ml
@@ -1,5 +1,3 @@
-#!/usr/bin/env ocaml
-
 #load "unix.cma"
 
 let freestanding =

--- a/test/test_runes.ml
+++ b/test/test_runes.ml
@@ -1,5 +1,3 @@
-#!/usr/bin/env ocaml
-
 #use "topfind"
 
 #require "astring"


### PR DESCRIPTION
This PR enables to build on platforms which don't have `env` on `/usr/bin`, for example `nix-build` (with [opam2nix](https://github.com/timbertson/opam2nix)) .
