### PR TITLE
Support MSVC compiler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,147 @@
+name: Cross-platform tests
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'feature-msvc'
+
+jobs:
+  test-with-setup-ocaml:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+        ocaml-compiler:
+          - '4.13.x'
+    runs-on: ${{ matrix.os }}
+    name: test-ocaml / ${{ matrix.os }}-${{ matrix.ocaml-compiler }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Hack Git CRLF for ocaml/setup-ocaml issue #529
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        run: |
+          & "C:\Program Files\Git\bin\git.exe" config --system core.autocrlf input
+
+      - name: OCaml ${{ matrix.ocaml-compiler }} with Dune cache
+        uses: ocaml/setup-ocaml@v2
+        if: ${{ !startsWith(matrix.os, 'windows-') }}
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
+      - name: OCaml ${{ matrix.ocaml-compiler }} without Dune cache
+        uses: ocaml/setup-ocaml@v2
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: false
+      - name: Install/build/test
+        run: |
+          opam install . --deps-only --with-test
+          opam exec -- dune build --display=short
+          opam exec -- dune runtest --display=short
+
+  setup-dkml:
+    uses: 'diskuv/dkml-workflows/.github/workflows/setup-dkml.yml@v0'
+    permissions: {} # remove all rights of GITHUB_TOKEN when it is passed to setup-dkml.yml
+    with:
+      ocaml-compiler: 4.12.1
+
+  test-with-setup-dkml:
+    needs: setup-dkml
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2019
+            abi-pattern: win32-windows_x86
+            dkml-host-abi: windows_x86
+            opam-root: D:/.opam
+            default_shell: msys2 {0}
+            msys2_system: MINGW32
+            msys2_packages: mingw-w64-i686-pkg-config
+            bits: "32"
+          - os: windows-2019
+            abi-pattern: win32-windows_x86_64
+            dkml-host-abi: windows_x86_64
+            opam-root: D:/.opam
+            default_shell: msys2 {0}
+            msys2_system: CLANG64
+            msys2_packages: mingw-w64-clang-x86_64-pkg-config
+            bits: "64"
+          - os: macos-latest
+            abi-pattern: macos-darwin_all
+            dkml-host-abi: darwin_x86_64
+            default_shell: sh
+            opam-root: /Users/runner/.opam
+            bits: "64"
+          - os: ubuntu-latest
+            abi-pattern: manylinux2014-linux_x86
+            bits: "32"
+            default_shell: sh
+            dkml-host-abi: linux_x86
+            opam-root: .ci/opamroot # local directory of $GITHUB_WORKSPACE so available to dockcross
+          - os: ubuntu-latest
+            abi-pattern: manylinux2014-linux_x86_64
+            bits: "64"
+            default_shell: sh
+            dkml-host-abi: linux_x86_64
+            opam-root: .ci/opamroot # local directory of $GITHUB_WORKSPACE so available to dockcross
+    runs-on: ${{ matrix.os }}
+    name: test-dkml / ${{ matrix.abi-pattern }}
+    defaults:
+      run:
+        shell: ${{ matrix.default_shell }}
+    env:
+      OPAMROOT: ${{ matrix.opam-root }}
+      COMPONENT: dkml-component-staging-opam${{ matrix.bits }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: .ci/dist
+
+      - name: Install MSYS2 (Windows)
+        if: startsWith(matrix.dkml-host-abi, 'windows_')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msys2_system }}
+          update: true
+          install: >-
+            ${{ matrix.msys2_packages }}
+            wget
+            make
+            rsync
+            diffutils
+            patch
+            unzip
+            git
+            tar
+
+      - name: Import build environments from setup-dkml
+        run: |
+          ${{ needs.setup-dkml.outputs.import_func }}
+          import ${{ matrix.abi-pattern }}
+
+      - name: Cache Opam downloads by host
+        uses: actions/cache@v3
+        with:
+          path: ${{ matrix.opam-root }}/download-cache
+          key: ${{ matrix.dkml-host-abi }}
+
+      - name: Install/build/test
+        run: |
+          # Fix dependencies to work with MSVC
+          #   - alcotest.1.4.0 works with MSVC; 1.5.0 does not
+          opamrun pin alcotest -k version 1.4.0 --no-action --yes
+
+          opamrun install . --deps-only --with-test --yes
+          opamrun exec -- dune build --display=short
+          opamrun exec -- dune runtest --display=short

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Pending
+
+- Support MSVC compiler (@jonahbeckford, #137)
+
 ### v1.1.2 2022-04-08 Paris (France)
 
 - Minor update on the README.md (@punchagan, #133)

--- a/src-c/native/bitfn.h
+++ b/src-c/native/bitfn.h
@@ -259,6 +259,9 @@ static __INLINE void store64( void *dst, uint64_t w )
 #elif defined( __QNXNTO__ ) && defined( __BIGENDIAN__ )
   # define BIG_ENDIAN 1234
   # define BYTE_ORDER    BIG_ENDIAN
+#elif defined(_MSC_VER)
+  # define LITTLE_ENDIAN	1234
+  # define BYTE_ORDER	    LITTLE_ENDIAN
 #else
   # include <endian.h>
 #endif

--- a/src-c/native/digestif.h
+++ b/src-c/native/digestif.h
@@ -32,7 +32,14 @@
 #endif
 
 #ifndef __unused
-#define __unused(x) x __attribute__((unused))
+# if defined(_MSC_VER) && _MSC_VER >= 1500
+#  define __unused(x) __pragma( warning (push) ) \
+    __pragma( warning (disable:4189 ) ) \
+    x \
+    __pragma( warning (pop))
+# else
+#  define __unused(x) x __attribute__((unused))
+# endif
 #endif
 #define __unit() value __unused(unit)
 


### PR DESCRIPTION
Some definitions are missing when using MSVC (`_MSC_VER`).

### Testing

I added GitHub Action testing using both `setup-ocaml` (which does traditional GCC compiling on Windows) and the soon-to-be-released slower `setup-dkml` (which uses MSVC; confer: https://github.com/diskuv/dkml-workflows#dkml-workflows). 

The test steps fail but that failure was pre-existing:
```
File "test/conv/dune", line 6, characters 0-75:
6 | (rule

7 |  (alias runtest)

8 |  (action

9 |   (run ./test_conv.exe --color=always)))

   test_conv alias test/conv/runtest (exit 2)
(cd _build/default/test/conv && ./test_conv.exe --color=always)
seed: [|[212](https://github.com/jonahbeckford/digestif/runs/6697770555?check_suite_focus=true#step:6:213)6519437; 30963195; 2828; 1331926406; 3|].
Fatal error: exception Sys_error("/dev/urandom: No such file or directory")
```
