### PR TITLE
Fix primitives used for bytes

### DIFF
--- a/src/digestif_by.ml
+++ b/src/digestif_by.ml
@@ -1,7 +1,7 @@
 include Bytes
 
-external unsafe_get_32 : t -> int -> int32 = "%caml_string_get32u"
-external unsafe_get_64 : t -> int -> int64 = "%caml_string_get64u"
+external unsafe_get_32 : t -> int -> int32 = "%caml_bytes_get32u"
+external unsafe_get_64 : t -> int -> int64 = "%caml_bytes_get64u"
 
 let unsafe_get_nat : t -> int -> nativeint =
  fun s i ->
@@ -9,8 +9,8 @@ let unsafe_get_nat : t -> int -> nativeint =
   then Nativeint.of_int32 @@ unsafe_get_32 s i
   else Int64.to_nativeint @@ unsafe_get_64 s i
 
-external unsafe_set_32 : t -> int -> int32 -> unit = "%caml_string_set32u"
-external unsafe_set_64 : t -> int -> int64 -> unit = "%caml_string_set64u"
+external unsafe_set_32 : t -> int -> int32 -> unit = "%caml_bytes_set32u"
+external unsafe_set_64 : t -> int -> int64 -> unit = "%caml_bytes_set64u"
 
 let unsafe_set_nat : t -> int -> nativeint -> unit =
  fun s i v ->


### PR DESCRIPTION
See https://github.com/ocsigen/js_of_ocaml/issues/1435

Starting with jsoo 5.1, string and bytes are not represented the same way. One can no longer mix primitives for string and bytes.