### PR TITLE
Update description to include SHA3

### DIFF
--- a/digestif.opam
+++ b/digestif.opam
@@ -22,6 +22,8 @@ We provides implementation of:
  * SHA256
  * SHA384
  * SHA512
+ * SHA3
+ * WHIRLPOOL
  * BLAKE2B
  * BLAKE2S
  * RIPEMD160


### PR DESCRIPTION
While searching for hash libraries on OPAM I was looking for SHA3 support I couldn't find `digestif` though according to its readme (and code) it does support SHA3, so in this PR I'm adding it to the description.

There is also Keccak-256, not sure if this should be mentioned given it is also missing from the README, but I am not sure how it differs from SHA3-256, so maybe someone with more knowledge can weight in.