### PR TITLE
Add lower bound on fmt

### DIFF
--- a/digestif.opam
+++ b/digestif.opam
@@ -43,7 +43,7 @@ depends: [
   "ocaml"           {>= "4.08.0"}
   "dune"            {>= "2.6.0"}
   "eqaf"
-  "fmt"             {with-test}
+  "fmt"             {with-test & >= "0.8.7"}
   "alcotest"        {with-test}
   "bos"             {with-test}
   "astring"         {with-test}


### PR DESCRIPTION
We use `Fmt.str` etc. which is introduced in fmt.0.8.7.