### PR TITLE
Use CAMLextern in caml_ forward declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Pending
+
+- Use `CAMLextern` rather than `extern` in `caml_*` forward declarations to
+  support bytecode linking on Windows (@jonahbeckford, #157)
+
 ### v1.2.0 2024-03-18 Paris (France)
 
 - Update the description to include SHA3 (@Leonidas-from-XIV, #146)

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -46,8 +46,8 @@
  * these functions still exist!
  */
 
-extern void caml_enter_blocking_section (void);
-extern void caml_leave_blocking_section (void);
+CAMLextern void caml_enter_blocking_section (void);
+CAMLextern void caml_leave_blocking_section (void);
 
 #define __define_ba_update(name)                                             \
   CAMLprim value                                                             \


### PR DESCRIPTION
This PR changes the `extern` attribute in `extern caml_...` to be exactly what OCaml uses (`CAMLextern`):

https://github.com/ocaml/ocaml/blob/b0b5f92896002239491308d3f1651d6e548c109f/runtime/caml/misc.h#L123-L136

### Fine Details

Without this change, on Windows 64-bit systems with OCaml bytecode you can get an obscure:

```text
Fatal error: cannot load shared library dlldigestif_c_stubs
Reason: flexdll error: cannot relocate caml_leave_blocking_section RELOC_REL32, target is too far: FFFFFFFF2EDEC956  000000002EDEC956
```

because `extern caml_leave_blocking_section` generates the following pseudo-assembly:

```asm
CALL caml_leave_blocking_section ; this is a 32-bit relative address
```

which does not work safely across DLL boundaries with flexdll.

The indirection introduced by `CAMLextern` makes the pseudo-assembly instead:

```asm
CALL [caml_leave_blocking_section] ; this is a 64-bit indirect address
```

which works well with flexdll.