### PR TITLE
Adds an example (OCaml Examples Project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ $ dune exec ./sha1sum.exe -- sha1sum.ml
 fe6e6639a817c23857b507e2d833ec776f23f327
 ```
 
+A further example is given in the examples directory.
+
 ## API
 
 For each hash, we implement the same API which is referentially transparent.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,17 @@
+# digestif
+
+This example is for the digestif library
+
+https://opam.ocaml.org/packages/digestif
+
+# Source file
+
+`bin/main.ml`
+
+# Building and running
+
+`dune exec bin/main.exe`
+
+# Cleaning up
+
+`dune clean`

--- a/examples/bin/dune
+++ b/examples/bin/dune
@@ -1,0 +1,3 @@
+(executable
+ (name main)
+ (libraries digestif))

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -1,0 +1,37 @@
+let go () =
+  let s = "Hello, World!\n" in
+  (* MD5 of a string *)
+  let md5 = Digestif.MD5.digest_string s in
+  Printf.printf "md5: %s\n" (Digestif.MD5.to_hex md5);
+  (* You can check this with echo 'Hello, World!' > foo then use md5sum foo
+     (Linux) or md5 foo (MacOS) on the command line. *)
+  (* We can send multiple strings too. Here, we send our string a byte at a time. *)
+  let context = ref (Digestif.MD5.init ()) in
+    for x = 0 to String.length s - 1 do
+      context := Digestif.MD5.feed_string !context ~off:x ~len:1 s
+    done;
+  (* Get the digest from the context *)
+  let md5' = Digestif.MD5.get !context in
+  Printf.printf "md5: %s\n" (Digestif.MD5.to_hex md5')
+
+(* SHA256 of a file *)
+let from_file filename =
+  (* A file's data is naturally read in chunks. *)
+  let fh = open_in_bin filename in
+  let buf = Bytes.create 1024 in
+  let context = ref (Digestif.SHA256.init ()) in
+  let fin = ref false in
+    while not !fin do
+      let n = input fh buf 0 1024 in
+        context := Digestif.SHA256.feed_bytes !context ~off:0 ~len:n buf;
+        if n = 0 then fin := true
+    done;
+  let sha256 = Digestif.SHA256.get !context in
+  Printf.printf "sha256: %s\n" (Digestif.SHA256.to_hex sha256)
+  (* You can check this with shasum -a 256 <file> on MacOS or sha256sum <file> on Linux. *)
+
+let () =
+  match Sys.argv with
+  | [|_|] -> go ()
+  | [|_; filename|] -> from_file filename
+  | _ -> Printf.eprintf "digestif example: unknown command line\n"

--- a/examples/bin/main.ml
+++ b/examples/bin/main.ml
@@ -34,4 +34,4 @@ let () =
   match Sys.argv with
   | [|_|] -> go ()
   | [|_; filename|] -> from_file filename
-  | _ -> Printf.eprintf "digestif example: unknown command line\n"
+  | _ -> Printf.eprintf "Usage: %s [<filename>]" Sys.argv.(0)

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(name digestif_example)

--- a/examples/dune-workspace
+++ b/examples/dune-workspace
@@ -1,0 +1,2 @@
+(lang dune 3.14)
+(env (dev (flags :standard -warn-error -A)))


### PR DESCRIPTION
Hello!

This pull request adds some examples to Digestif. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library.

As well as considering accepting this pull request, please give any comments you have on this programme.