### PR TITLE
blake2: reject a digest size below 1

### DIFF
--- a/src-c/digestif.ml
+++ b/src-c/digestif.ml
@@ -324,7 +324,7 @@ end
 
 module Make_BLAKE2 (F : Foreign_BLAKE2) (D : Desc) = struct
   let () =
-    if D.digest_size > F.max_outlen ()
+    if D.digest_size < 1 || D.digest_size > F.max_outlen ()
     then
       failwith "Invalid digest_size:%d to make a BLAKE2{S,B} implementation"
         D.digest_size

--- a/src-ocaml/digestif.ml
+++ b/src-ocaml/digestif.ml
@@ -294,7 +294,7 @@ end
 
 module Make_BLAKE2 (H : Hash_BLAKE2) (D : Desc) = struct
   let () =
-    if D.digest_size > H.max_outlen
+    if D.digest_size < 1 || D.digest_size > H.max_outlen
     then
       failwith "Invalid digest_size:%d to make a BLAKE2{S,B} implementation"
         D.digest_size


### PR DESCRIPTION
`Make_BLAKE2` only checks the upper bound on `digest_size`, so a size below 1 (e.g. `-1`) is accepted; in the C backend it wraps to a `uint8_t` (255) and `finalise` writes past the caller's destination buffer. Reject `digest_size < 1` as well, in both the C and pure-OCaml backends.