### PR TITLE
Apply xor_into on unaligned buffers and be safe on word-aligned architectures

### DIFF
--- a/src-c/native/misc.c
+++ b/src-c/native/misc.c
@@ -1,40 +1,40 @@
 #include "digestif.h"
 
-#define u_long_s sizeof (unsigned long)
+#define u_long_s sizeof(unsigned long)
 
-static inline void xor_into (uint8_t *src, uint8_t *dst, size_t n) {
-#if defined (__digestif_SSE2__)
+static inline void xor_into(uint8_t *src, uint8_t *dst, size_t n) {
+#if defined(__digestif_SSE2__)
   while (n >= 16) {
-    _mm_storeu_si128 (
-        (__m128i*) dst,
-        _mm_xor_si128 (
-          _mm_loadu_si128 ((__m128i*) src),
-          _mm_loadu_si128 ((__m128i*) dst)));
+    _mm_storeu_si128((__m128i *)dst,
+                     _mm_xor_si128(_mm_loadu_si128((__m128i *)src),
+                                   _mm_loadu_si128((__m128i *)dst)));
     src += 16;
     dst += 16;
-    n   -= 16;
+    n -= 16;
   }
 #endif
-  while (n >= u_long_s) {
-    *((u_long *) dst) ^= *((u_long *) src);
-    src += u_long_s;
-    dst += u_long_s;
-    n   -= u_long_s;
-  }
-  while (n-- > 0) {
-    *dst = *(src ++) ^ *dst;
-    dst++;
-  }
+#ifdef ARCH_SIXTYFOUR
+  uint64_t s;
+  for (; n >= 8; n -= 8, src += 8, dst += 8)
+    *(uint64_t *)dst ^= *(uint64_t *)memcpy(&s, src, 8);
+#endif
+
+  uint32_t t;
+  for (; n >= 4; n -= 4, src += 4, dst += 4)
+    *(uint32_t *)dst ^= *(uint32_t *)memcpy(&t, src, 4);
+
+  for (; n--; ++src, ++dst)
+    *dst = *src ^ *dst;
 }
 
-CAMLprim value
-caml_digestif_ba_xor_into (value b1, value off1, value b2, value off2, value n) {
-  xor_into (_ba_uint8_off (b1, off1), _ba_uint8_off (b2, off2), Int_val (n));
+CAMLprim value caml_digestif_ba_xor_into(value b1, value off1, value b2,
+                                         value off2, value n) {
+  xor_into(_ba_uint8_off(b1, off1), _ba_uint8_off(b2, off2), Int_val(n));
   return Val_unit;
 }
 
-CAMLprim value
-caml_digestif_st_xor_into (value b1, value off1, value b2, value off2, value n) {
-  xor_into (_st_uint8_off (b1, off1), _st_uint8_off (b2, off2), Int_val (n));
+CAMLprim value caml_digestif_st_xor_into(value b1, value off1, value b2,
+                                         value off2, value n) {
+  xor_into(_st_uint8_off(b1, off1), _st_uint8_off(b2, off2), Int_val(n));
   return Val_unit;
 }


### PR DESCRIPTION
Took from https://github.com/mirage/mirage-crypto/pull/81, may be @hannesm would like to review it. A question arise about `digestif` and `mirage-crypto` and if we can share such function but I think, due to the variant layout of `digestif`, it's preferable to have it in `digestif` also (`digestif.ocaml` will not provide such function to `mirage-crypto` for instance).

Fix #167 